### PR TITLE
Fix /exit and /quit not terminating the process

### DIFF
--- a/src/cli/chat.ts
+++ b/src/cli/chat.ts
@@ -96,7 +96,9 @@ export const chatCommand = new Command('chat')
             case '/quit':
               console.log('');
               printDim('Goodbye!');
-              return;
+              rl.close();
+              process.exit(0);
+              return; // unreachable, but keeps TS happy
 
             case '/help':
               printHelp();
@@ -190,6 +192,8 @@ export const chatCommand = new Command('chat')
       }
     } finally {
       rl.close();
+      stdin.pause();
+      stdin.unref();
     }
   });
 


### PR DESCRIPTION
## Summary

- `/exit` and `/quit` slash commands in the interactive REPL did not terminate the process because `return` only exited the action handler while `stdin` remained open, keeping the Node.js event loop alive
- Now calls `process.exit(0)` explicitly (matching the existing `SIGINT` handler behavior)
- Added `stdin.pause()` and `stdin.unref()` in the `finally` block as a safety net for other exit paths

## Test plan

- [x] `pnpm build` — passes
- [x] `pnpm lint` — passes
- [x] `pnpm format:check` — passes
- [x] `pnpm test` — 28/28 tests pass
- [x] Functional test: `echo '/exit' | node dist/index.js chat` exits cleanly within 3s (verified)

Fixes #1


Made with [Cursor](https://cursor.com)