### PR TITLE
Prompt disclaimer every session instead of caching acceptance

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ CLI flags  >  Environment variables  >  Config file  >  Defaults
 
 ## Security
 
-- **First-launch disclaimer.** On first run, CaretForge displays a disclaimer explaining what it can do and asks for explicit acceptance. This is persisted so you only see it once.
+- **Session disclaimer.** Every time you start CaretForge, a disclaimer is displayed and you must accept before proceeding. Acceptance is never cached to disk.
 - **Permission prompts by default.** Write and shell tools require explicit user approval per action (or `--allow-write` / `--allow-shell` to auto-approve).
 - **Secrets are never printed in full.** The `config show` command and logs use redaction (first 4, last 2 characters).
 - **`config init` does not write API keys** unless you pass `--with-secrets`.

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -21,8 +21,7 @@ On first run, CaretForge displays a disclaimer explaining what it can do:
 ```
 
 - You must explicitly accept to continue
-- Acceptance is saved to `~/.config/caretforge/.accepted-terms`
-- The prompt only appears once per machine
+- The prompt appears **every time** you start a session — acceptance is never cached
 - Non-TTY environments (piped input) cannot accept and will exit
 
 ## Secret Handling


### PR DESCRIPTION
## Summary

- Removed all filesystem-based acceptance caching (`~/.config/caretforge/.accepted-terms`)
- Removed `hasAcceptedDisclaimer`, `saveAcceptance`, and related `fs`/`path` imports from `src/ui/disclaimer.ts`
- The disclaimer now displays **every time** `caretforge` is launched, requiring explicit acceptance before proceeding
- Updated README and security docs to reflect the new behavior

## Test plan

- [x] `pnpm build` — passes
- [x] `pnpm lint` — passes
- [x] `pnpm format:check` — passes
- [x] `pnpm test` — 28/28 tests pass
- [x] Functional test: two consecutive runs both hit the disclaimer (no cached bypass)

Fixes #3


Made with [Cursor](https://cursor.com)