### PR TITLE
Fix Pino INFO log clobbering the first prompt

### DIFF
--- a/src/cli/chat.ts
+++ b/src/cli/chat.ts
@@ -60,7 +60,9 @@ export const chatCommand = new Command('chat')
       readline: rl,
     });
 
-    log.info({ provider: provider.name, model, stream }, 'Starting chat session');
+    // Use debug (not info) so the structured log only appears with --trace.
+    // The banner below is the user-facing startup output and is synchronous.
+    log.debug({ provider: provider.name, model, stream }, 'Starting chat session');
     printBanner(provider.name, model);
     printDim(`${fileIndex.length} files indexed · use @filename to add context`);
     console.log('');


### PR DESCRIPTION
## Summary

- Downgraded the `log.info()` "Starting chat session" call to `log.debug()` in `src/cli/chat.ts`
- The Pino `info` log was async (pino-pretty worker thread) and raced with readline's `> ` prompt, printing after it and requiring an extra Enter
- Now only appears with `--trace`; the synchronous `printBanner()` already shows the same info to the user

## Test plan

- [x] `pnpm build` — passes
- [x] `pnpm lint` — passes
- [x] `pnpm format:check` — passes
- [x] `pnpm test` — 28/28 tests pass
- [x] Manual test by user

Fixes #6


Made with [Cursor](https://cursor.com)