### PR TITLE
Add file indexing governance with 7-point safety model

### DIFF
--- a/src/ui/fileContext.ts
+++ b/src/ui/fileContext.ts
@@ -1,11 +1,42 @@
 /**
  * @file context system — index files in cwd, tab-complete @paths,
  * and expand @references into file content for the model.
+ *
+ * Governance (modeled after Claude Code):
+ *  1. File size limits — skip large files, cap expansion
+ *  2. .gitignore respect — use git ls-files when available
+ *  3. Binary detection — text extension whitelist
+ *  4. Symlink safety — cycle detection, skip special files
+ *  5. Timeout guard — abort indexing after deadline
+ *  6. Configurable ignore — .caretforgeignore support
+ *  7. File size display — show sizes in browse output
  */
-import { readdir, readFile, stat } from 'node:fs/promises';
-import { join, relative } from 'node:path';
+import { readdir, readFile, stat, lstat, realpath, access } from 'node:fs/promises';
+import { existsSync, readFileSync } from 'node:fs';
+import { join, relative, extname } from 'node:path';
+import { execFile } from 'node:child_process';
 
-// ── Ignore patterns ─────────────────────────────────────────
+// ── Constants ───────────────────────────────────────────────
+
+/** Max file size (bytes) to include in the index. Files larger are skipped. */
+export const MAX_INDEX_FILE_SIZE = 1_048_576; // 1 MB
+
+/** Max content size (bytes) when expanding an @file reference. */
+export const MAX_EXPANSION_SIZE = 262_144; // 256 KB
+
+/** Max line length (chars) before truncation during expansion. */
+export const MAX_LINE_LENGTH = 2_000;
+
+/** Max lines returned per @file expansion. */
+export const MAX_EXPANSION_LINES = 2_000;
+
+const MAX_DEPTH = 4;
+const MAX_FILES = 5_000;
+
+/** Indexing timeout in milliseconds. */
+export const INDEX_TIMEOUT_MS = 10_000;
+
+// ── Ignored directories (fallback when not using git) ───────
 
 const IGNORED_DIRS = new Set([
   'node_modules',
@@ -31,92 +62,472 @@ const IGNORED_DIRS = new Set([
   'vendor',
 ]);
 
-const MAX_DEPTH = 4;
-const MAX_FILES = 5000;
+// ── Text extension whitelist (Point 3: binary detection) ────
 
-// ── File indexing ───────────────────────────────────────────
+export const TEXT_EXTENSIONS = new Set([
+  '.md',
+  '.txt',
+  '.text',
+  '.json',
+  '.yaml',
+  '.yml',
+  '.toml',
+  '.xml',
+  '.csv',
+  '.html',
+  '.htm',
+  '.css',
+  '.scss',
+  '.sass',
+  '.less',
+  '.js',
+  '.ts',
+  '.tsx',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.mts',
+  '.cts',
+  '.py',
+  '.pyi',
+  '.pyw',
+  '.rb',
+  '.erb',
+  '.rake',
+  '.go',
+  '.rs',
+  '.java',
+  '.kt',
+  '.kts',
+  '.scala',
+  '.c',
+  '.cpp',
+  '.cc',
+  '.cxx',
+  '.h',
+  '.hpp',
+  '.hxx',
+  '.cs',
+  '.swift',
+  '.sh',
+  '.bash',
+  '.zsh',
+  '.fish',
+  '.ps1',
+  '.bat',
+  '.cmd',
+  '.env',
+  '.ini',
+  '.cfg',
+  '.conf',
+  '.config',
+  '.properties',
+  '.sql',
+  '.graphql',
+  '.gql',
+  '.proto',
+  '.vue',
+  '.svelte',
+  '.astro',
+  '.ejs',
+  '.hbs',
+  '.pug',
+  '.jade',
+  '.php',
+  '.pl',
+  '.pm',
+  '.lua',
+  '.r',
+  '.dart',
+  '.ex',
+  '.exs',
+  '.erl',
+  '.hrl',
+  '.clj',
+  '.cljs',
+  '.cljc',
+  '.edn',
+  '.hs',
+  '.lhs',
+  '.elm',
+  '.ml',
+  '.mli',
+  '.f',
+  '.f90',
+  '.f95',
+  '.for',
+  '.cmake',
+  '.make',
+  '.makefile',
+  '.gradle',
+  '.sbt',
+  '.rst',
+  '.adoc',
+  '.asciidoc',
+  '.org',
+  '.tex',
+  '.latex',
+  '.lock',
+  '.log',
+  '.diff',
+  '.patch',
+  '.dockerfile',
+  '.dockerignore',
+  '.gitignore',
+  '.gitattributes',
+  '.editorconfig',
+  '.prettierrc',
+  '.eslintrc',
+  '.babelrc',
+  '.npmrc',
+  '.nvmrc',
+  '.env.example',
+  '.tf',
+  '.tfvars',
+  '.hcl',
+  '.prisma',
+  '.mdx',
+]);
+
+/** Files with no extension that are known text files. */
+const TEXT_FILENAMES = new Set([
+  'Makefile',
+  'Dockerfile',
+  'Vagrantfile',
+  'Gemfile',
+  'Rakefile',
+  'Procfile',
+  'LICENSE',
+  'LICENCE',
+  'CHANGELOG',
+  'CONTRIBUTING',
+  'AUTHORS',
+  'CODEOWNERS',
+  '.gitignore',
+  '.gitattributes',
+  '.editorconfig',
+  '.dockerignore',
+  '.prettierignore',
+  '.eslintignore',
+  '.npmignore',
+]);
 
 /**
- * Recursively index files under `root`, returning relative paths.
- * Skips common ignored directories and respects depth/count limits.
+ * Check if a filename looks like a text file based on its extension
+ * or known filename.
  */
-export async function indexFiles(root: string, maxDepth = MAX_DEPTH): Promise<string[]> {
-  const files: string[] = [];
+export function isTextFile(filename: string): boolean {
+  const ext = extname(filename).toLowerCase();
+  if (ext && TEXT_EXTENSIONS.has(ext)) return true;
+  // Check bare filename (e.g. Makefile, LICENSE)
+  const base = filename.split('/').pop() ?? filename;
+  return TEXT_FILENAMES.has(base);
+}
+
+// ── .caretforgeignore support (Point 6) ─────────────────────
+
+/**
+ * Load ignore patterns from .caretforgeignore in the given directory.
+ * Returns a list of gitignore-style patterns, or empty if no file.
+ */
+export function loadIgnorePatterns(root: string): string[] {
+  const ignorePath = join(root, '.caretforgeignore');
+  if (!existsSync(ignorePath)) return [];
+  try {
+    const content = readFileSync(ignorePath, 'utf-8');
+    return content
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l && !l.startsWith('#'));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Simple gitignore-style pattern matcher. Supports:
+ *  - exact filenames: "secret.key"
+ *  - directory patterns: "logs/" (matches any path containing /logs/)
+ *  - glob prefix: "*.log" (matches files ending in .log)
+ *  - path prefix: "dist/" (matches paths starting with dist/)
+ */
+export function matchesIgnorePattern(relPath: string, patterns: string[]): boolean {
+  for (const pattern of patterns) {
+    // Directory pattern: "logs/" matches any segment
+    if (pattern.endsWith('/')) {
+      const dir = pattern.slice(0, -1);
+      if (relPath.startsWith(dir + '/') || relPath.includes('/' + dir + '/')) return true;
+      continue;
+    }
+    // Glob: "*.ext"
+    if (pattern.startsWith('*.')) {
+      const ext = pattern.slice(1); // ".ext"
+      if (relPath.endsWith(ext)) return true;
+      continue;
+    }
+    // Exact match or path prefix
+    if (relPath === pattern || relPath.startsWith(pattern + '/')) return true;
+    // Match basename
+    const base = relPath.split('/').pop() ?? relPath;
+    if (base === pattern) return true;
+  }
+  return false;
+}
+
+// ── File metadata for browse display (Point 7) ─────────────
+
+export interface IndexedFile {
+  path: string;
+  size: number;
+}
+
+// ── Git-based file discovery (Point 2) ──────────────────────
+
+/**
+ * Check if a directory is inside a git repository.
+ */
+async function isGitRepo(dir: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    execFile('git', ['rev-parse', '--is-inside-work-tree'], { cwd: dir, timeout: 3000 }, (err) => {
+      resolve(!err);
+    });
+  });
+}
+
+/**
+ * Use `git ls-files` to get tracked files (respects .gitignore).
+ * Returns relative paths or null if git is unavailable.
+ */
+async function gitListFiles(root: string, timeoutMs: number): Promise<string[] | null> {
+  return new Promise((resolve) => {
+    execFile(
+      'git',
+      ['ls-files', '--cached', '--others', '--exclude-standard'],
+      { cwd: root, timeout: timeoutMs, maxBuffer: 20_000_000 },
+      (err, stdout) => {
+        if (err) {
+          resolve(null);
+          return;
+        }
+        const files = stdout
+          .split('\n')
+          .map((l) => l.trim())
+          .filter(Boolean);
+        resolve(files);
+      },
+    );
+  });
+}
+
+// ── Core indexing (all 7 points integrated) ─────────────────
+
+export interface IndexResult {
+  files: IndexedFile[];
+  timedOut: boolean;
+  method: 'git' | 'walk';
+  skippedLarge: number;
+  skippedBinary: number;
+  skippedIgnored: number;
+}
+
+/**
+ * Index files under `root` with full governance:
+ *  1. File size limits
+ *  2. .gitignore respect (git ls-files)
+ *  3. Binary detection (text extension whitelist)
+ *  4. Symlink safety (cycle detection)
+ *  5. Timeout guard
+ *  6. .caretforgeignore patterns
+ *  7. Collects file sizes for display
+ */
+export async function indexFiles(root: string, maxDepth = MAX_DEPTH): Promise<IndexedFile[]> {
+  const result = await indexFilesWithMeta(root, maxDepth);
+  return result.files;
+}
+
+export async function indexFilesWithMeta(root: string, maxDepth = MAX_DEPTH): Promise<IndexResult> {
+  const deadline = Date.now() + INDEX_TIMEOUT_MS;
+  const ignorePatterns = loadIgnorePatterns(root);
+  let skippedLarge = 0;
+  let skippedBinary = 0;
+  let skippedIgnored = 0;
+
+  // Try git ls-files first (Point 2)
+  const inGit = await isGitRepo(root);
+  if (inGit) {
+    const remainingMs = Math.max(1000, deadline - Date.now());
+    const gitFiles = await gitListFiles(root, remainingMs);
+    if (gitFiles) {
+      const files: IndexedFile[] = [];
+      for (const relPath of gitFiles) {
+        if (Date.now() > deadline) {
+          return {
+            files,
+            timedOut: true,
+            method: 'git',
+            skippedLarge,
+            skippedBinary,
+            skippedIgnored,
+          };
+        }
+        if (files.length >= MAX_FILES) break;
+
+        // Point 6: .caretforgeignore
+        if (ignorePatterns.length > 0 && matchesIgnorePattern(relPath, ignorePatterns)) {
+          skippedIgnored++;
+          continue;
+        }
+
+        // Point 3: binary detection
+        if (!isTextFile(relPath)) {
+          skippedBinary++;
+          continue;
+        }
+
+        // Point 1: file size check
+        try {
+          const s = await stat(join(root, relPath));
+          if (s.size > MAX_INDEX_FILE_SIZE) {
+            skippedLarge++;
+            continue;
+          }
+          files.push({ path: relPath, size: s.size });
+        } catch {
+          // Skip unreadable
+        }
+      }
+      files.sort((a, b) => a.path.localeCompare(b.path));
+      return {
+        files,
+        timedOut: false,
+        method: 'git',
+        skippedLarge,
+        skippedBinary,
+        skippedIgnored,
+      };
+    }
+  }
+
+  // Fallback: recursive readdir walk with all governance
+  const files: IndexedFile[] = [];
+  const visitedRealPaths = new Set<string>(); // Point 4: symlink cycle detection
 
   async function walk(dir: string, depth: number): Promise<void> {
     if (depth > maxDepth || files.length >= MAX_FILES) return;
+    if (Date.now() > deadline) return; // Point 5: timeout
 
     let entries;
     try {
       entries = await readdir(dir, { withFileTypes: true });
     } catch {
-      return; // permission denied, etc.
+      return; // permission denied
     }
 
     for (const entry of entries) {
-      if (files.length >= MAX_FILES) break;
+      if (files.length >= MAX_FILES || Date.now() > deadline) break;
+
+      const fullPath = join(dir, entry.name);
+
+      // Point 4: symlink safety — detect cycles and special files
+      if (entry.isSymbolicLink()) {
+        try {
+          const real = await realpath(fullPath);
+          if (visitedRealPaths.has(real)) continue; // cycle
+          visitedRealPaths.add(real);
+          const ls = await lstat(real);
+          if (ls.isFIFO() || ls.isSocket() || ls.isCharacterDevice() || ls.isBlockDevice()) {
+            continue; // skip special files
+          }
+        } catch {
+          continue; // broken symlink
+        }
+      }
 
       if (entry.name.startsWith('.') && entry.isDirectory()) continue;
 
       if (entry.isDirectory()) {
         if (IGNORED_DIRS.has(entry.name)) continue;
-        await walk(join(dir, entry.name), depth + 1);
+        await walk(fullPath, depth + 1);
       } else {
-        files.push(relative(root, join(dir, entry.name)));
+        const relPath = relative(root, fullPath);
+
+        // Point 6: .caretforgeignore
+        if (ignorePatterns.length > 0 && matchesIgnorePattern(relPath, ignorePatterns)) {
+          skippedIgnored++;
+          continue;
+        }
+
+        // Point 3: binary detection
+        if (!isTextFile(relPath)) {
+          skippedBinary++;
+          continue;
+        }
+
+        // Point 1: file size limit
+        try {
+          const s = await stat(fullPath);
+          if (s.size > MAX_INDEX_FILE_SIZE) {
+            skippedLarge++;
+            continue;
+          }
+          files.push({ path: relPath, size: s.size });
+        } catch {
+          // skip
+        }
       }
     }
   }
 
   await walk(root, 0);
-  files.sort();
-  return files;
+  files.sort((a, b) => a.path.localeCompare(b.path));
+  return {
+    files,
+    timedOut: Date.now() > deadline,
+    method: 'walk',
+    skippedLarge,
+    skippedBinary,
+    skippedIgnored,
+  };
 }
 
 // ── Tab completion ──────────────────────────────────────────
 
-/**
- * Create a readline completer that handles @filepath tab-completion.
- * Returns a standard Node.js readline completer function.
- */
-export function createFileCompleter(files: string[]): (line: string) => [string[], string] {
+export function createFileCompleter(files: IndexedFile[]): (line: string) => [string[], string] {
   return function completer(line: string): [string[], string] {
-    // Find the last @token in the line
     const match = line.match(/@([^\s]*)$/);
     if (!match) return [[], line];
 
     const partial = match[1] ?? '';
-    const hits = files.filter((f) => f.startsWith(partial));
+    const hits = files.filter((f) => f.path.startsWith(partial));
 
     if (hits.length === 0) return [[], line];
 
-    // Return completions: readline replaces the matched substring
-    return [hits.map((h) => '@' + h), match[0]];
+    return [hits.map((h) => '@' + h.path), match[0]];
   };
 }
 
-// ── Interactive file browsing ────────────────────────────────
+// ── Interactive file browsing (Point 7: size display) ───────
 
 const MAX_BROWSE_RESULTS = 50;
 
-/**
- * Check if the input is a bare @-browse query (just "@" or "@prefix"
- * with no other text). Returns the prefix if so, or null otherwise.
- */
 export function parseBrowseQuery(input: string): string | null {
   const match = input.match(/^@([^\s]*)$/);
   if (!match) return null;
   return match[1] ?? '';
 }
 
-/**
- * Find indexed files matching a prefix and return them grouped by
- * top-level directory for readable display.
- */
+/** Format bytes into human-readable size. */
+export function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 export function matchFiles(
-  files: string[],
+  files: IndexedFile[],
   prefix: string,
-): { matches: string[]; total: number; truncated: boolean } {
-  const matches = files.filter((f) => f.startsWith(prefix));
+): { matches: IndexedFile[]; total: number; truncated: boolean } {
+  const matches = files.filter((f) => f.path.startsWith(prefix));
   const total = matches.length;
   const truncated = total > MAX_BROWSE_RESULTS;
   return {
@@ -126,41 +537,44 @@ export function matchFiles(
   };
 }
 
-// ── Reference expansion ─────────────────────────────────────
+// ── Reference expansion (Point 1: size/line caps) ───────────
 
-/** A resolved @file reference. */
 export interface FileReference {
   path: string;
   content: string;
+  truncated: boolean;
+  originalSize: number;
 }
 
 /**
- * Find all @filepath tokens in a message, read each file,
- * and return the enriched prompt with file context prepended.
+ * Expand @file references with governance:
+ *  - Cap content at MAX_EXPANSION_SIZE (256 KB)
+ *  - Cap at MAX_EXPANSION_LINES (2,000 lines)
+ *  - Truncate lines over MAX_LINE_LENGTH (2,000 chars)
+ *  - Skip binary files
  */
 export async function expandFileReferences(
   message: string,
-  knownFiles: string[],
+  knownFiles: IndexedFile[],
 ): Promise<{ expandedMessage: string; refs: FileReference[] }> {
-  // Match @filepath tokens (not preceded by another word char)
   const tokenRegex = /@([^\s]+)/g;
   const refs: FileReference[] = [];
   const seenPaths = new Set<string>();
+  const knownPaths = new Set(knownFiles.map((f) => f.path));
 
   let match: RegExpExecArray | null;
   while ((match = tokenRegex.exec(message)) !== null) {
     const filePath = match[1];
     if (!filePath) continue;
-
-    // Only expand if it looks like a known file or actually exists
     if (seenPaths.has(filePath)) continue;
 
-    const isKnown = knownFiles.includes(filePath);
+    // Check if known or exists on disk
+    const isKnown = knownPaths.has(filePath);
     let exists = isKnown;
 
     if (!isKnown) {
       try {
-        await stat(filePath);
+        await access(filePath);
         exists = true;
       } catch {
         exists = false;
@@ -169,12 +583,40 @@ export async function expandFileReferences(
 
     if (!exists) continue;
 
+    // Point 3: skip binary files
+    if (!isTextFile(filePath)) continue;
+
     try {
-      const content = await readFile(filePath, 'utf-8');
-      refs.push({ path: filePath, content });
+      const fileStat = await stat(filePath);
+      const originalSize = fileStat.size;
+      let truncated = false;
+
+      // Point 1: cap at MAX_EXPANSION_SIZE
+      let raw: string;
+      if (originalSize > MAX_EXPANSION_SIZE) {
+        // Read only the first MAX_EXPANSION_SIZE bytes
+        const fullContent = await readFile(filePath, 'utf-8');
+        raw = fullContent.slice(0, MAX_EXPANSION_SIZE);
+        truncated = true;
+      } else {
+        raw = await readFile(filePath, 'utf-8');
+      }
+
+      // Point 1: truncate lines and cap line count
+      let lines = raw.split('\n');
+      if (lines.length > MAX_EXPANSION_LINES) {
+        lines = lines.slice(0, MAX_EXPANSION_LINES);
+        truncated = true;
+      }
+      lines = lines.map((l) =>
+        l.length > MAX_LINE_LENGTH ? l.slice(0, MAX_LINE_LENGTH) + '…' : l,
+      );
+      const content = lines.join('\n');
+
+      refs.push({ path: filePath, content, truncated, originalSize });
       seenPaths.add(filePath);
     } catch {
-      // Can't read — skip silently
+      // Can't read — skip
     }
   }
 
@@ -182,11 +624,14 @@ export async function expandFileReferences(
     return { expandedMessage: message, refs: [] };
   }
 
-  // Build context block
-  const contextParts = refs.map((r) => `[File: ${r.path}]\n${r.content}`);
+  const contextParts = refs.map((r) => {
+    const header = r.truncated
+      ? `[File: ${r.path} (truncated from ${formatSize(r.originalSize)})]`
+      : `[File: ${r.path}]`;
+    return `${header}\n${r.content}`;
+  });
   const context = contextParts.join('\n\n');
 
-  // Strip the @ prefixes from the original message for cleaner reading
   const cleanMessage = message.replace(/@([^\s]+)/g, (full, path: string) => {
     return seenPaths.has(path) ? path : full;
   });

--- a/test/fileContext.test.ts
+++ b/test/fileContext.test.ts
@@ -1,0 +1,474 @@
+/**
+ * Tests for file indexing governance (Issue #14).
+ * Covers all 7 governance points:
+ *  1. File size limits
+ *  2. .gitignore respect
+ *  3. Binary file detection
+ *  4. Symlink safety
+ *  5. Timeout guard
+ *  6. Configurable ignore patterns (.caretforgeignore)
+ *  7. File size display in browse output
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, symlinkSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  indexFilesWithMeta,
+  isTextFile,
+  loadIgnorePatterns,
+  matchesIgnorePattern,
+  formatSize,
+  matchFiles,
+  expandFileReferences,
+  createFileCompleter,
+  parseBrowseQuery,
+  MAX_INDEX_FILE_SIZE,
+  MAX_EXPANSION_SIZE,
+  MAX_LINE_LENGTH,
+  MAX_EXPANSION_LINES,
+  TEXT_EXTENSIONS,
+  type IndexedFile,
+} from '../src/ui/fileContext.js';
+
+// ── Helpers ──────────────────────────────────────────────────
+
+let testDir: string;
+
+function setup() {
+  testDir = mkdtempSync(join(tmpdir(), 'caretforge-test-'));
+}
+
+function cleanup() {
+  rmSync(testDir, { recursive: true, force: true });
+}
+
+function createFile(relPath: string, content: string) {
+  const full = join(testDir, relPath);
+  const dir = full.substring(0, full.lastIndexOf('/'));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(full, content);
+}
+
+function createLargeFile(relPath: string, sizeBytes: number) {
+  const full = join(testDir, relPath);
+  const dir = full.substring(0, full.lastIndexOf('/'));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(full, Buffer.alloc(sizeBytes, 'a'));
+}
+
+// ══════════════════════════════════════════════════════════════
+// Point 1: File Size Limits
+// ══════════════════════════════════════════════════════════════
+
+describe('Point 1: File size limits', () => {
+  beforeEach(setup);
+  afterEach(cleanup);
+
+  it('should index files under MAX_INDEX_FILE_SIZE', async () => {
+    createFile('small.ts', 'export const a = 1;');
+    const result = await indexFilesWithMeta(testDir);
+    expect(result.files.length).toBe(1);
+    expect(result.files[0].path).toBe('small.ts');
+    expect(result.skippedLarge).toBe(0);
+  });
+
+  it('should skip files exceeding MAX_INDEX_FILE_SIZE', async () => {
+    createFile('small.ts', 'ok');
+    createLargeFile('huge.ts', MAX_INDEX_FILE_SIZE + 1);
+    const result = await indexFilesWithMeta(testDir);
+    expect(result.files.map((f) => f.path)).toEqual(['small.ts']);
+    expect(result.skippedLarge).toBe(1);
+  });
+
+  it('should cap expansion at MAX_EXPANSION_SIZE', async () => {
+    // Create a file larger than 256 KB but under 1 MB
+    const bigContent = 'x'.repeat(MAX_EXPANSION_SIZE + 10_000) + '\n';
+    createFile('bigfile.ts', bigContent);
+    const files: IndexedFile[] = [{ path: join(testDir, 'bigfile.ts'), size: bigContent.length }];
+    const { refs } = await expandFileReferences(`@${join(testDir, 'bigfile.ts')}`, files);
+    expect(refs.length).toBe(1);
+    expect(refs[0].truncated).toBe(true);
+    expect(refs[0].content.length).toBeLessThanOrEqual(MAX_EXPANSION_SIZE + 100); // small buffer for line splitting
+  });
+
+  it('should truncate lines exceeding MAX_LINE_LENGTH', async () => {
+    const longLine = 'a'.repeat(MAX_LINE_LENGTH + 500);
+    createFile('longlines.ts', longLine + '\nshort\n');
+    const files: IndexedFile[] = [
+      { path: join(testDir, 'longlines.ts'), size: longLine.length + 7 },
+    ];
+    const { refs } = await expandFileReferences(`@${join(testDir, 'longlines.ts')}`, files);
+    expect(refs.length).toBe(1);
+    const lines = refs[0].content.split('\n');
+    // First line should be truncated
+    expect(lines[0].length).toBeLessThanOrEqual(MAX_LINE_LENGTH + 5); // +5 for "…" char
+    expect(lines[0].endsWith('…')).toBe(true);
+  });
+
+  it('should cap expansion at MAX_EXPANSION_LINES', async () => {
+    const manyLines = Array.from({ length: MAX_EXPANSION_LINES + 500 }, (_, i) => `line ${i}`).join(
+      '\n',
+    );
+    createFile('manylines.ts', manyLines);
+    const files: IndexedFile[] = [{ path: join(testDir, 'manylines.ts'), size: manyLines.length }];
+    const { refs } = await expandFileReferences(`@${join(testDir, 'manylines.ts')}`, files);
+    expect(refs.length).toBe(1);
+    expect(refs[0].truncated).toBe(true);
+    const lineCount = refs[0].content.split('\n').length;
+    expect(lineCount).toBeLessThanOrEqual(MAX_EXPANSION_LINES);
+  });
+
+  it('should include file size in IndexedFile', async () => {
+    const content = 'hello world';
+    createFile('sized.ts', content);
+    const result = await indexFilesWithMeta(testDir);
+    expect(result.files.length).toBe(1);
+    expect(result.files[0].size).toBe(content.length);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Point 2: .gitignore respect
+// ══════════════════════════════════════════════════════════════
+
+describe('Point 2: .gitignore respect', () => {
+  let gitDir: string;
+
+  beforeEach(() => {
+    gitDir = mkdtempSync(join(tmpdir(), 'caretforge-git-'));
+  });
+
+  afterEach(() => {
+    rmSync(gitDir, { recursive: true, force: true });
+  });
+
+  it('should use git ls-files when in a git repo', async () => {
+    // Initialize a git repo
+    const { execFileSync } = await import('node:child_process');
+    execFileSync('git', ['init'], { cwd: gitDir });
+    execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd: gitDir });
+    execFileSync('git', ['config', 'user.name', 'test'], { cwd: gitDir });
+
+    // Create tracked files
+    writeFileSync(join(gitDir, 'tracked.ts'), 'const a = 1;');
+    writeFileSync(join(gitDir, '.gitignore'), 'ignored/\n');
+    mkdirSync(join(gitDir, 'ignored'));
+    writeFileSync(join(gitDir, 'ignored', 'secret.ts'), 'secret');
+
+    execFileSync('git', ['add', '.'], { cwd: gitDir });
+    execFileSync('git', ['commit', '-m', 'init'], { cwd: gitDir });
+
+    // Create an untracked-but-not-ignored file
+    writeFileSync(join(gitDir, 'untracked.ts'), 'const b = 2;');
+
+    const result = await indexFilesWithMeta(gitDir);
+    expect(result.method).toBe('git');
+    const paths = result.files.map((f) => f.path);
+    expect(paths).toContain('tracked.ts');
+    expect(paths).toContain('untracked.ts');
+    // The gitignored file should not appear
+    expect(paths).not.toContain('ignored/secret.ts');
+  });
+
+  it('should fall back to walk when not in a git repo', async () => {
+    setup();
+    createFile('hello.ts', 'const x = 1;');
+    const result = await indexFilesWithMeta(testDir);
+    expect(result.method).toBe('walk');
+    expect(result.files.length).toBe(1);
+    cleanup();
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Point 3: Binary file detection
+// ══════════════════════════════════════════════════════════════
+
+describe('Point 3: Binary file detection', () => {
+  beforeEach(setup);
+  afterEach(cleanup);
+
+  it('should identify text files by extension', () => {
+    expect(isTextFile('main.ts')).toBe(true);
+    expect(isTextFile('styles.css')).toBe(true);
+    expect(isTextFile('config.json')).toBe(true);
+    expect(isTextFile('readme.md')).toBe(true);
+    expect(isTextFile('script.py')).toBe(true);
+    expect(isTextFile('Makefile')).toBe(true);
+    expect(isTextFile('Dockerfile')).toBe(true);
+    expect(isTextFile('LICENSE')).toBe(true);
+  });
+
+  it('should reject binary file extensions', () => {
+    expect(isTextFile('image.png')).toBe(false);
+    expect(isTextFile('photo.jpg')).toBe(false);
+    expect(isTextFile('archive.zip')).toBe(false);
+    expect(isTextFile('binary.exe')).toBe(false);
+    expect(isTextFile('library.so')).toBe(false);
+    expect(isTextFile('font.woff2')).toBe(false);
+    expect(isTextFile('data.db')).toBe(false);
+    expect(isTextFile('video.mp4')).toBe(false);
+  });
+
+  it('should skip binary files during indexing', async () => {
+    createFile('code.ts', 'const a = 1;');
+    createFile('image.png', '\x89PNG fake binary');
+    createFile('data.bin', '\x00\x01\x02\x03');
+    const result = await indexFilesWithMeta(testDir);
+    expect(result.files.map((f) => f.path)).toEqual(['code.ts']);
+    expect(result.skippedBinary).toBe(2);
+  });
+
+  it('should skip binary files during @expansion', async () => {
+    createFile('code.ts', 'hello');
+    createFile('image.png', 'fake png data');
+    const files: IndexedFile[] = [
+      { path: join(testDir, 'code.ts'), size: 5 },
+      { path: join(testDir, 'image.png'), size: 13 },
+    ];
+    const { refs } = await expandFileReferences(
+      `check @${join(testDir, 'code.ts')} and @${join(testDir, 'image.png')}`,
+      files,
+    );
+    expect(refs.length).toBe(1);
+    expect(refs[0].path).toBe(join(testDir, 'code.ts'));
+  });
+
+  it('should have a comprehensive text extension whitelist', () => {
+    // Spot-check known extensions
+    const knownTextExts = ['.ts', '.js', '.py', '.go', '.rs', '.java', '.json', '.yaml', '.md'];
+    for (const ext of knownTextExts) {
+      expect(TEXT_EXTENSIONS.has(ext)).toBe(true);
+    }
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Point 4: Symlink safety
+// ══════════════════════════════════════════════════════════════
+
+describe('Point 4: Symlink safety', () => {
+  beforeEach(setup);
+  afterEach(cleanup);
+
+  it('should follow valid symlinks to files', async () => {
+    createFile('real.ts', 'export const x = 1;');
+    symlinkSync(join(testDir, 'real.ts'), join(testDir, 'link.ts'));
+    const result = await indexFilesWithMeta(testDir);
+    const paths = result.files.map((f) => f.path);
+    expect(paths).toContain('real.ts');
+    expect(paths).toContain('link.ts');
+  });
+
+  it('should detect and skip symlink cycles', async () => {
+    mkdirSync(join(testDir, 'dirA'));
+    createFile('dirA/file.ts', 'hello');
+    // Create a symlink cycle: dirA/loop -> testDir (parent)
+    symlinkSync(testDir, join(testDir, 'dirA', 'loop'));
+    const result = await indexFilesWithMeta(testDir);
+    // Should still index the real file without infinite recursion
+    const paths = result.files.map((f) => f.path);
+    expect(paths).toContain('dirA/file.ts');
+    // The function should terminate (this test passing = no infinite loop)
+  });
+
+  it('should skip broken symlinks', async () => {
+    createFile('real.ts', 'hello');
+    symlinkSync(join(testDir, 'nonexistent.ts'), join(testDir, 'broken-link.ts'));
+    const result = await indexFilesWithMeta(testDir);
+    const paths = result.files.map((f) => f.path);
+    expect(paths).toContain('real.ts');
+    // broken-link.ts should be skipped (not cause an error)
+    expect(paths).not.toContain('broken-link.ts');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Point 5: Timeout guard
+// ══════════════════════════════════════════════════════════════
+
+describe('Point 5: Timeout guard', () => {
+  beforeEach(setup);
+  afterEach(cleanup);
+
+  it('should return partial results with timedOut flag when timeout exceeded', async () => {
+    // We can't easily simulate a real timeout in a unit test, but we can
+    // verify the timeout machinery exists by checking that indexFilesWithMeta
+    // returns an IndexResult with a timedOut field
+    createFile('file1.ts', 'a');
+    createFile('file2.ts', 'b');
+    const result = await indexFilesWithMeta(testDir);
+    expect(typeof result.timedOut).toBe('boolean');
+    expect(result.timedOut).toBe(false);
+    // All files indexed within timeout
+    expect(result.files.length).toBe(2);
+  });
+
+  it('should report method used (git or walk)', async () => {
+    createFile('hello.ts', 'x');
+    const result = await indexFilesWithMeta(testDir);
+    expect(['git', 'walk']).toContain(result.method);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Point 6: Configurable ignore patterns (.caretforgeignore)
+// ══════════════════════════════════════════════════════════════
+
+describe('Point 6: .caretforgeignore support', () => {
+  beforeEach(setup);
+  afterEach(cleanup);
+
+  it('should load patterns from .caretforgeignore', () => {
+    writeFileSync(join(testDir, '.caretforgeignore'), '# Comment\n*.log\nsecret.ts\nlogs/\n\n');
+    const patterns = loadIgnorePatterns(testDir);
+    expect(patterns).toEqual(['*.log', 'secret.ts', 'logs/']);
+  });
+
+  it('should return empty when no .caretforgeignore exists', () => {
+    const patterns = loadIgnorePatterns(testDir);
+    expect(patterns).toEqual([]);
+  });
+
+  it('should match exact filename patterns', () => {
+    expect(matchesIgnorePattern('secret.ts', ['secret.ts'])).toBe(true);
+    expect(matchesIgnorePattern('other.ts', ['secret.ts'])).toBe(false);
+  });
+
+  it('should match glob extension patterns', () => {
+    expect(matchesIgnorePattern('debug.log', ['*.log'])).toBe(true);
+    expect(matchesIgnorePattern('src/app.log', ['*.log'])).toBe(true);
+    expect(matchesIgnorePattern('readme.md', ['*.log'])).toBe(false);
+  });
+
+  it('should match directory patterns', () => {
+    expect(matchesIgnorePattern('logs/debug.log', ['logs/'])).toBe(true);
+    expect(matchesIgnorePattern('src/logs/file.ts', ['logs/'])).toBe(true);
+    expect(matchesIgnorePattern('logger.ts', ['logs/'])).toBe(false);
+  });
+
+  it('should match basename patterns', () => {
+    expect(matchesIgnorePattern('src/nested/secret.ts', ['secret.ts'])).toBe(true);
+  });
+
+  it('should skip ignored files during indexing', async () => {
+    writeFileSync(join(testDir, '.caretforgeignore'), '*.log\nsecret.ts\n');
+    createFile('app.ts', 'const a = 1;');
+    createFile('debug.log', 'log data');
+    createFile('secret.ts', 'const key = "abc";');
+    const result = await indexFilesWithMeta(testDir);
+    expect(result.files.map((f) => f.path)).toEqual(['app.ts']);
+    expect(result.skippedIgnored).toBe(2);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Point 7: File size display in browse output
+// ══════════════════════════════════════════════════════════════
+
+describe('Point 7: File size display', () => {
+  it('should format bytes correctly', () => {
+    expect(formatSize(0)).toBe('0 B');
+    expect(formatSize(512)).toBe('512 B');
+    expect(formatSize(1024)).toBe('1.0 KB');
+    expect(formatSize(1536)).toBe('1.5 KB');
+    expect(formatSize(1048576)).toBe('1.0 MB');
+    expect(formatSize(2621440)).toBe('2.5 MB');
+  });
+
+  it('should include size in IndexedFile results', async () => {
+    setup();
+    const content = 'x'.repeat(100);
+    createFile('sized.ts', content);
+    const result = await indexFilesWithMeta(testDir);
+    expect(result.files.length).toBe(1);
+    expect(result.files[0].size).toBe(100);
+    cleanup();
+  });
+
+  it('should return IndexedFile objects from matchFiles', () => {
+    const files: IndexedFile[] = [
+      { path: 'src/a.ts', size: 100 },
+      { path: 'src/b.ts', size: 2048 },
+      { path: 'README.md', size: 500 },
+    ];
+    const { matches } = matchFiles(files, 'src/');
+    expect(matches.length).toBe(2);
+    expect(matches[0].path).toBe('src/a.ts');
+    expect(matches[0].size).toBe(100);
+    expect(matches[1].path).toBe('src/b.ts');
+    expect(matches[1].size).toBe(2048);
+  });
+
+  it('should truncate browse results at 50', () => {
+    const files: IndexedFile[] = Array.from({ length: 100 }, (_, i) => ({
+      path: `file${String(i).padStart(3, '0')}.ts`,
+      size: i * 10,
+    }));
+    const { matches, total, truncated } = matchFiles(files, '');
+    expect(total).toBe(100);
+    expect(truncated).toBe(true);
+    expect(matches.length).toBe(50);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Tab completion and browse with new types
+// ══════════════════════════════════════════════════════════════
+
+describe('Tab completion and browse', () => {
+  it('should complete @filepath with IndexedFile', () => {
+    const files: IndexedFile[] = [
+      { path: 'src/main.ts', size: 100 },
+      { path: 'src/utils.ts', size: 200 },
+      { path: 'README.md', size: 50 },
+    ];
+    const completer = createFileCompleter(files);
+    const [completions] = completer('check @src/');
+    expect(completions).toEqual(['@src/main.ts', '@src/utils.ts']);
+  });
+
+  it('should parse browse queries', () => {
+    expect(parseBrowseQuery('@')).toBe('');
+    expect(parseBrowseQuery('@src/')).toBe('src/');
+    expect(parseBrowseQuery('hello @src/')).toBeNull();
+    expect(parseBrowseQuery('plain text')).toBeNull();
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Expansion with governance
+// ══════════════════════════════════════════════════════════════
+
+describe('Expansion governance', () => {
+  beforeEach(setup);
+  afterEach(cleanup);
+
+  it('should expand text file references and report truncation', async () => {
+    createFile('hello.ts', 'export const msg = "hello";');
+    const files: IndexedFile[] = [{ path: join(testDir, 'hello.ts'), size: 27 }];
+    const { refs, expandedMessage } = await expandFileReferences(
+      `read @${join(testDir, 'hello.ts')}`,
+      files,
+    );
+    expect(refs.length).toBe(1);
+    expect(refs[0].truncated).toBe(false);
+    expect(refs[0].originalSize).toBe(27);
+    expect(expandedMessage).toContain('export const msg');
+  });
+
+  it('should include truncation header for large files', async () => {
+    const bigContent = 'line\n'.repeat(MAX_EXPANSION_LINES + 100);
+    createFile('big.ts', bigContent);
+    const files: IndexedFile[] = [{ path: join(testDir, 'big.ts'), size: bigContent.length }];
+    const { refs, expandedMessage } = await expandFileReferences(
+      `@${join(testDir, 'big.ts')}`,
+      files,
+    );
+    expect(refs[0].truncated).toBe(true);
+    expect(expandedMessage).toContain('[File:');
+    expect(expandedMessage).toContain('truncated from');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #14

Implements Claude Code-inspired file indexing governance for CWD protection. All 7 points from the issue are addressed:

1. **File size limits** — Files >1 MB are skipped during indexing. `@` expansion is capped at 256 KB, lines truncated at 2,000 chars, and output capped at 2,000 lines.
2. **`.gitignore` respect** — Uses `git ls-files --cached --others --exclude-standard` when inside a git repo, falling back to recursive readdir walk otherwise.
3. **Binary file detection** — 120+ text extension whitelist plus known text filenames (Makefile, Dockerfile, LICENSE, etc.). Binary files are skipped in both indexing and `@` expansion.
4. **Symlink safety** — Tracks visited real paths to detect cycles. Skips broken symlinks and special files (FIFOs, sockets, character/block devices).
5. **Timeout guard** — 10-second deadline on indexing. Returns partial results with `timedOut: true` flag and displays a warning to the user.
6. **Configurable ignore patterns** — `.caretforgeignore` file support with glob (`*.log`), directory (`logs/`), exact filename, and basename patterns.
7. **File size display** — Browse output now shows human-readable file sizes. Index stats report binary/large/ignored skip counts and method used (git vs walk).

## Test plan

- [x] 33 new tests in `test/fileContext.test.ts` covering all 7 governance points
- [x] Point 1: Tests for size skip, expansion cap, line truncation, line count cap
- [x] Point 2: Tests for git ls-files usage and walk fallback
- [x] Point 3: Tests for text/binary detection, binary skip in index and expansion
- [x] Point 4: Tests for symlink follow, cycle detection, broken symlink skip
- [x] Point 5: Tests for timeout flag presence and method reporting
- [x] Point 6: Tests for .caretforgeignore loading, pattern matching (glob, directory, exact, basename), and skip during indexing
- [x] Point 7: Tests for formatSize, IndexedFile in matchFiles, browse truncation
- [x] All 96 tests pass (33 new + 63 existing)
- [x] Build, lint, and format all pass


Made with [Cursor](https://cursor.com)