### PR TITLE
Fix Prettier formatting in docs from #41

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,12 +170,12 @@ caretforge run "List all TODO comments" --json
 
 CaretForge supports multiple providers through a pluggable interface:
 
-| Provider           | Models                       | Status    |
-| ------------------ | ---------------------------- | --------- |
-| `azure-anthropic`  | Claude Opus, Sonnet, etc.    | **Ready** |
-| `azure-foundry`    | GPT-4o, GPT-4.1, Kimi K2.5  | **Ready** |
-| `azure-responses`  | gpt-5.2-codex, codex-mini    | **Ready** |
-| `azure-agents`     | Azure AI Agent Service       | Preview   |
+| Provider          | Models                     | Status    |
+| ----------------- | -------------------------- | --------- |
+| `azure-anthropic` | Claude Opus, Sonnet, etc.  | **Ready** |
+| `azure-foundry`   | GPT-4o, GPT-4.1, Kimi K2.5 | **Ready** |
+| `azure-responses` | gpt-5.2-codex, codex-mini  | **Ready** |
+| `azure-agents`    | Azure AI Agent Service     | Preview   |
 
 ### Adding a New Provider
 

--- a/docs/guide/tools.md
+++ b/docs/guide/tools.md
@@ -73,12 +73,12 @@ CaretForge uses an interactive permission model inspired by [Claude Code](https:
 
 Before any shell command is executed (even with `--allow-shell`), CaretForge classifies it into a risk tier:
 
-| Risk Level     | Behavior                                                   | Examples                                        |
-| -------------- | ---------------------------------------------------------- | ----------------------------------------------- |
-| **Safe**       | Auto-approved with `--allow-shell`; normal prompt otherwise | `ls`, `cat`, `grep`, `git status`, `node -v`   |
-| **Mutating**   | Normal permission prompt                                    | `npm install`, `git commit`, `mkdir`            |
-| **Destructive** | Always prompts (even with `--allow-shell`), shown in red   | `rm`, `sudo`, `chmod -R`, `kill -9`, `shutdown` |
-| **Blocked**    | Denied outright — never executed                            | `rm -rf /`, fork bombs, `curl ... \| bash`       |
+| Risk Level      | Behavior                                                    | Examples                                        |
+| --------------- | ----------------------------------------------------------- | ----------------------------------------------- |
+| **Safe**        | Auto-approved with `--allow-shell`; normal prompt otherwise | `ls`, `cat`, `grep`, `git status`, `node -v`    |
+| **Mutating**    | Normal permission prompt                                    | `npm install`, `git commit`, `mkdir`            |
+| **Destructive** | Always prompts (even with `--allow-shell`), shown in red    | `rm`, `sudo`, `chmod -R`, `kill -9`, `shutdown` |
+| **Blocked**     | Denied outright — never executed                            | `rm -rf /`, fork bombs, `curl ... \| bash`      |
 
 Piped and chained commands (using `|`, `&&`, or `;`) are analyzed segment by segment. If any segment is destructive or blocked, the entire command inherits that classification.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -60,15 +60,15 @@ caretforge --provider azure-foundry --allow-write
 
 **Slash commands** available inside the REPL:
 
-| Command       | Description                                     |
-| ------------- | ----------------------------------------------- |
-| `/help`       | Show available commands                          |
-| `/model`      | List models from all configured providers        |
-| `/model <id>` | Switch model mid-conversation                    |
-| `/clear`      | Clear conversation history                       |
-| `/compact`    | Trim older messages from history                 |
-| `/exit`       | Exit CaretForge                                  |
-| `/quit`       | Exit CaretForge (alias)                          |
+| Command       | Description                               |
+| ------------- | ----------------------------------------- |
+| `/help`       | Show available commands                   |
+| `/model`      | List models from all configured providers |
+| `/model <id>` | Switch model mid-conversation             |
+| `/clear`      | Clear conversation history                |
+| `/compact`    | Trim older messages from history          |
+| `/exit`       | Exit CaretForge                           |
+| `/quit`       | Exit CaretForge (alias)                   |
 
 You can also type `exit`, `quit`, or `q` without the slash to leave the REPL.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -115,11 +115,11 @@ Path: `providers.azureResponses`
 
 For models that use the OpenAI Responses API instead of Chat Completions (e.g. `gpt-5.2-codex`, `codex-mini`).
 
-| Field      | Type           | Required | Default | Description                                   |
-| ---------- | -------------- | -------- | ------- | --------------------------------------------- |
-| `endpoint` | `string (URL)` | Yes      | —       | `https://RESOURCE.openai.azure.com`           |
-| `apiKey`   | `string`       | Yes      | —       | Azure API key                                 |
-| `models`   | `array`        | No       | `[]`    | Available models                              |
+| Field      | Type           | Required | Default | Description                         |
+| ---------- | -------------- | -------- | ------- | ----------------------------------- |
+| `endpoint` | `string (URL)` | Yes      | —       | `https://RESOURCE.openai.azure.com` |
+| `apiKey`   | `string`       | Yes      | —       | Azure API key                       |
+| `models`   | `array`        | No       | `[]`    | Available models                    |
 
 ### URL Construction
 

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -76,12 +76,12 @@ Without any flags, the agent can only **read files**. It cannot:
 
 Before any shell command or file write is executed, CaretForge classifies it into a risk tier:
 
-| Risk Level      | Behavior                                                     |
-| --------------- | ------------------------------------------------------------ |
-| **Safe**        | Auto-approved with `--allow-shell`; normal prompt otherwise  |
-| **Mutating**    | Normal permission prompt                                      |
+| Risk Level      | Behavior                                                          |
+| --------------- | ----------------------------------------------------------------- |
+| **Safe**        | Auto-approved with `--allow-shell`; normal prompt otherwise       |
+| **Mutating**    | Normal permission prompt                                          |
 | **Destructive** | Always prompts, even with `--allow-shell`, shown with red warning |
-| **Blocked**     | Denied outright — never executed                              |
+| **Blocked**     | Denied outright — never executed                                  |
 
 #### Safe Commands
 
@@ -198,12 +198,12 @@ On startup, indexing statistics are shown:
 
 ### Indexing Limits
 
-| Limit         | Value  |
-| ------------- | ------ |
-| Max files     | 5,000  |
-| Max depth     | 4      |
-| Max file size | 1 MB   |
-| Timeout       | 10 s   |
+| Limit         | Value |
+| ------------- | ----- |
+| Max files     | 5,000 |
+| Max depth     | 4     |
+| Max file size | 1 MB  |
+| Timeout       | 10 s  |
 
 ## Agent Loop Limits
 


### PR DESCRIPTION
## Summary

- Whitespace-only formatting fixes (table alignment, trailing spaces) in 5 doc files
- These files were edited in PR #41 but `pnpm format` was not run before pushing, causing the `format` CI check to fail

## Files changed

All changes are whitespace-only (Prettier table column alignment):

- `README.md`
- `docs/guide/tools.md`
- `docs/reference/cli.md`
- `docs/reference/configuration.md`
- `docs/reference/security.md`

## Test plan

- [x] `pnpm format:check` passes locally
- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (96/96)
- [x] Secret scan clean

Made with [Cursor](https://cursor.com)