### PR TITLE
Add edit_file tool for in-place file modifications

### DIFF
--- a/docs/guide/tools.md
+++ b/docs/guide/tools.md
@@ -27,6 +27,30 @@ When the model wants to write a file, you'll see:
   Allow? [y]es / [n]o / [a]lways
 ```
 
+### `edit_file` — Requires Permission
+
+Performs a surgical, in-place edit on a file by finding and replacing an exact string match. More efficient than `write_file` for small changes — the model doesn't need to re-emit the entire file.
+
+```bash
+caretforge "Fix the typo in README.md"
+```
+
+When the model wants to edit a file, you'll see:
+
+```
+  ⚡ Edit README.md
+  Allow? [y]es / [n]o / [a]lways
+```
+
+Parameters:
+
+- **`path`** — The file to edit
+- **`old_string`** — Exact text to find (must match uniquely)
+- **`new_string`** — Replacement text
+- **`replace_all`** _(optional)_ — If `true`, replace all occurrences instead of requiring a unique match
+
+The tool fails with a clear error if `old_string` is not found or matches multiple locations (unless `replace_all` is set). This prevents accidental edits.
+
 ### `exec_shell` — Requires Permission
 
 Executes a shell command and returns stdout, stderr, and exit code.
@@ -142,6 +166,9 @@ Tool calls are displayed inline during execution:
 
   ▶ Write src/hello.ts
     ✓ Wrote 15 lines to /Users/you/project/src/hello.ts
+
+  ▶ Edit src/utils.ts
+    ✓ Edited src/utils.ts: replaced 1 occurrence (no line count change)
 
   ▶ $ npm test
     ✓ exit 0

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -47,7 +47,7 @@ export interface AgentResult {
 const DEFAULT_MAX_ITERATIONS = 20;
 
 // Tools that require explicit permission
-const DANGEROUS_TOOLS = new Set(['write_file', 'exec_shell']);
+const DANGEROUS_TOOLS = new Set(['write_file', 'edit_file', 'exec_shell']);
 
 // ── Agent loop ────────────────────────────────────────────────
 

--- a/src/tools/editFile.ts
+++ b/src/tools/editFile.ts
@@ -1,0 +1,149 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { ToolError } from '../util/errors.js';
+
+export interface EditFileArgs {
+  path: string;
+  old_string: string;
+  new_string: string;
+  replace_all?: boolean;
+}
+
+/**
+ * Count non-overlapping occurrences of `needle` in `haystack`.
+ */
+function countOccurrences(haystack: string, needle: string): number {
+  let count = 0;
+  let pos = 0;
+  while ((pos = haystack.indexOf(needle, pos)) !== -1) {
+    count++;
+    pos += needle.length;
+  }
+  return count;
+}
+
+/**
+ * Build a short context snippet around the first replacement site.
+ * Shows up to 3 lines before and after the change.
+ */
+function buildDiffPreview(
+  original: string,
+  newContent: string,
+  oldString: string,
+  newString: string,
+): string {
+  const CONTEXT_LINES = 3;
+
+  // Find which line the first replacement starts on
+  const pos = original.indexOf(oldString);
+  if (pos === -1) return '';
+
+  const beforeReplace = original.slice(0, pos);
+  const startLine = beforeReplace.split('\n').length - 1;
+
+  const oldLines = oldString.split('\n');
+  const newLines = newString.split('\n');
+
+  const allNewLines = newContent.split('\n');
+  const contextStart = Math.max(0, startLine - CONTEXT_LINES);
+  const contextEnd = Math.min(allNewLines.length, startLine + newLines.length + CONTEXT_LINES);
+
+  const parts: string[] = [];
+
+  // Show removed lines
+  const origAllLines = original.split('\n');
+  const oldEnd = Math.min(origAllLines.length, startLine + oldLines.length + CONTEXT_LINES);
+  const oldContextStart = Math.max(0, startLine - CONTEXT_LINES);
+
+  parts.push('  --- before');
+  for (let i = oldContextStart; i < oldEnd; i++) {
+    const prefix =
+      i >= startLine && i < startLine + oldLines.length ? chalk_red_prefix : chalk_dim_prefix;
+    parts.push(`  ${prefix}${origAllLines[i]}`);
+  }
+
+  parts.push('  +++ after');
+  for (let i = contextStart; i < contextEnd; i++) {
+    const prefix =
+      i >= startLine && i < startLine + newLines.length ? chalk_green_prefix : chalk_dim_prefix;
+    parts.push(`  ${prefix}${allNewLines[i]}`);
+  }
+
+  return parts.join('\n');
+}
+
+// Simple prefixes for diff display (no chalk dependency in tool layer)
+const chalk_red_prefix = '- ';
+const chalk_green_prefix = '+ ';
+const chalk_dim_prefix = '  ';
+
+/**
+ * Edit a file by finding and replacing exact string matches.
+ * Permission checking is handled by the agent loop before this function is called.
+ */
+export async function executeEditFile(args: EditFileArgs): Promise<string> {
+  const target = resolve(args.path);
+  const { old_string, new_string, replace_all } = args;
+
+  // Read the existing file
+  let content: string;
+  try {
+    content = await readFile(target, 'utf-8');
+  } catch (err) {
+    throw new ToolError(`Failed to read file "${target}": ${(err as Error).message}`, err as Error);
+  }
+
+  // Count occurrences
+  const count = countOccurrences(content, old_string);
+
+  if (count === 0) {
+    throw new ToolError(
+      `old_string not found in "${target}". Make sure the text matches exactly, including whitespace and indentation.`,
+    );
+  }
+
+  if (count > 1 && !replace_all) {
+    throw new ToolError(
+      `old_string matches ${count} locations in "${target}". Provide more surrounding context to uniquely identify the edit, or set replace_all to true.`,
+    );
+  }
+
+  // Perform replacement
+  let newContent: string;
+  let replacements: number;
+  if (replace_all) {
+    newContent = content.split(old_string).join(new_string);
+    replacements = count;
+  } else {
+    // Replace only the first occurrence
+    const pos = content.indexOf(old_string);
+    newContent = content.slice(0, pos) + new_string + content.slice(pos + old_string.length);
+    replacements = 1;
+  }
+
+  // Write back
+  try {
+    await writeFile(target, newContent, 'utf-8');
+  } catch (err) {
+    throw new ToolError(
+      `Failed to write file "${target}": ${(err as Error).message}`,
+      err as Error,
+    );
+  }
+
+  // Build summary
+  const oldLineCount = content.split('\n').length;
+  const newLineCount = newContent.split('\n').length;
+  const lineDelta = newLineCount - oldLineCount;
+  const lineDeltaStr =
+    lineDelta === 0
+      ? 'no line count change'
+      : lineDelta > 0
+        ? `+${lineDelta} line${lineDelta !== 1 ? 's' : ''}`
+        : `${lineDelta} line${lineDelta !== -1 ? 's' : ''}`;
+
+  const preview = buildDiffPreview(content, newContent, old_string, new_string);
+  const summary = `Edited ${target}: replaced ${replacements} occurrence${replacements !== 1 ? 's' : ''} (${lineDeltaStr})`;
+
+  return preview ? `${summary}\n${preview}` : summary;
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,6 +1,7 @@
 import type { ToolCall } from '../providers/provider.js';
 import { executeReadFile } from './readFile.js';
 import { executeWriteFile } from './writeFile.js';
+import { executeEditFile } from './editFile.js';
 import { executeShell } from './execShell.js';
 import { ToolError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
@@ -34,6 +35,14 @@ export async function executeTool(toolCall: ToolCall): Promise<string> {
       return executeWriteFile({
         path: args['path'] as string,
         content: args['content'] as string,
+      });
+
+    case 'edit_file':
+      return executeEditFile({
+        path: args['path'] as string,
+        old_string: args['old_string'] as string,
+        new_string: args['new_string'] as string,
+        replace_all: args['replace_all'] as boolean | undefined,
       });
 
     case 'exec_shell':

--- a/src/tools/schema.ts
+++ b/src/tools/schema.ts
@@ -48,6 +48,40 @@ export const WRITE_FILE_TOOL: ToolDefinition = {
   },
 };
 
+export const EDIT_FILE_TOOL: ToolDefinition = {
+  type: 'function',
+  function: {
+    name: 'edit_file',
+    description:
+      'Edit a file by replacing an exact string match with new content. More efficient than write_file for small changes — avoids rewriting the entire file.',
+    parameters: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Absolute or relative file path to edit.',
+        },
+        old_string: {
+          type: 'string',
+          description:
+            'The exact text to find in the file. Must match exactly, including whitespace and indentation.',
+        },
+        new_string: {
+          type: 'string',
+          description: 'The text to replace old_string with.',
+        },
+        replace_all: {
+          type: 'boolean',
+          description:
+            'If true, replace all occurrences of old_string. Defaults to false (single replacement).',
+        },
+      },
+      required: ['path', 'old_string', 'new_string'],
+      additionalProperties: false,
+    },
+  },
+};
+
 export const EXEC_SHELL_TOOL: ToolDefinition = {
   type: 'function',
   function: {
@@ -81,7 +115,7 @@ export const EXEC_SHELL_TOOL: ToolDefinition = {
  * permission checking happens at execution time, not at selection time.
  */
 export function getAllTools(): ToolDefinition[] {
-  return [READ_FILE_TOOL, WRITE_FILE_TOOL, EXEC_SHELL_TOOL];
+  return [READ_FILE_TOOL, WRITE_FILE_TOOL, EDIT_FILE_TOOL, EXEC_SHELL_TOOL];
 }
 
 /**

--- a/src/ui/format.ts
+++ b/src/ui/format.ts
@@ -29,6 +29,8 @@ export function formatToolCallStart(name: string, args: Record<string, unknown>)
       return `  ${chalk.cyan('▶')} ${chalk.bold('Read')} ${chalk.yellow(String(args['path']))}`;
     case 'write_file':
       return `  ${chalk.cyan('▶')} ${chalk.bold('Write')} ${chalk.yellow(String(args['path']))}`;
+    case 'edit_file':
+      return `  ${chalk.cyan('▶')} ${chalk.bold('Edit')} ${chalk.yellow(String(args['path']))}`;
     case 'exec_shell':
       return `  ${chalk.cyan('▶')} ${chalk.bold('$')} ${chalk.dim(String(args['command']))}`;
     default:
@@ -43,6 +45,8 @@ export function formatToolResult(name: string, result: string): string {
       return chalk.dim(`    ${lines} line${lines !== 1 ? 's' : ''}`);
     }
     case 'write_file':
+      return `    ${chalk.green('✓')} ${chalk.dim(result)}`;
+    case 'edit_file':
       return `    ${chalk.green('✓')} ${chalk.dim(result)}`;
     case 'exec_shell': {
       try {
@@ -82,6 +86,8 @@ export function formatPermissionRequest(toolName: string, args: Record<string, u
   let description: string;
   if (toolName === 'write_file') {
     description = `Write to ${chalk.yellow(String(args['path']))}`;
+  } else if (toolName === 'edit_file') {
+    description = `Edit ${chalk.yellow(String(args['path']))}`;
   } else if (toolName === 'exec_shell') {
     description = `Run ${chalk.yellow(String(args['command']))}`;
   } else {

--- a/src/ui/permissions.ts
+++ b/src/ui/permissions.ts
@@ -89,8 +89,8 @@ export class PermissionManager {
       return this.promptUser(toolName, args);
     }
 
-    // ── write_file safety analysis ────────────────────────
-    if (toolName === 'write_file') {
+    // ── write_file / edit_file safety analysis ─────────────
+    if (toolName === 'write_file' || toolName === 'edit_file') {
       const filePath = String(args['path'] ?? '');
       const verdict = analyseWritePath(filePath);
 
@@ -142,7 +142,7 @@ export class PermissionManager {
 
       // "always" only available for non-destructive actions
       if (!escalationReason && (normalised === 'a' || normalised === 'always')) {
-        if (toolName === 'write_file') this.state.alwaysWrite = true;
+        if (toolName === 'write_file' || toolName === 'edit_file') this.state.alwaysWrite = true;
         if (toolName === 'exec_shell') this.state.alwaysShell = true;
         return true;
       }

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -2,18 +2,20 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { getAllTools } from '../src/tools/schema.js';
 import { executeReadFile } from '../src/tools/readFile.js';
 import { executeWriteFile } from '../src/tools/writeFile.js';
+import { executeEditFile } from '../src/tools/editFile.js';
 import { executeShell } from '../src/tools/execShell.js';
 import { join } from 'node:path';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 
 describe('getAllTools', () => {
-  it('always returns all three tools', () => {
+  it('returns all four tools', () => {
     const tools = getAllTools();
-    expect(tools).toHaveLength(3);
+    expect(tools).toHaveLength(4);
     const names = tools.map((t) => t.function.name);
     expect(names).toContain('read_file');
     expect(names).toContain('write_file');
+    expect(names).toContain('edit_file');
     expect(names).toContain('exec_shell');
   });
 });
@@ -53,6 +55,116 @@ describe('executeWriteFile', () => {
     const target = join(tmpDir, 'a', 'b', 'c.txt');
     const result = await executeWriteFile({ path: target, content: 'nested' });
     expect(result).toContain('Wrote');
+  });
+});
+
+describe('executeEditFile', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'caretforge-edit-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('replaces a single occurrence and reports success', async () => {
+    const target = join(tmpDir, 'file.txt');
+    await writeFile(target, 'hello world\nfoo bar\n', 'utf-8');
+    const result = await executeEditFile({
+      path: target,
+      old_string: 'foo bar',
+      new_string: 'baz qux',
+    });
+    expect(result).toContain('Edited');
+    expect(result).toContain('replaced 1 occurrence');
+    const content = await readFile(target, 'utf-8');
+    expect(content).toBe('hello world\nbaz qux\n');
+  });
+
+  it('preserves the rest of the file unchanged', async () => {
+    const target = join(tmpDir, 'preserve.txt');
+    const original = 'line1\nline2\nTARGET\nline4\nline5\n';
+    await writeFile(target, original, 'utf-8');
+    await executeEditFile({
+      path: target,
+      old_string: 'TARGET',
+      new_string: 'REPLACED',
+    });
+    const content = await readFile(target, 'utf-8');
+    expect(content).toBe('line1\nline2\nREPLACED\nline4\nline5\n');
+  });
+
+  it('throws when old_string is not found', async () => {
+    const target = join(tmpDir, 'notfound.txt');
+    await writeFile(target, 'hello world\n', 'utf-8');
+    await expect(
+      executeEditFile({
+        path: target,
+        old_string: 'does not exist',
+        new_string: 'replacement',
+      }),
+    ).rejects.toThrow('old_string not found');
+  });
+
+  it('throws when old_string matches multiple locations without replace_all', async () => {
+    const target = join(tmpDir, 'multi.txt');
+    await writeFile(target, 'aaa\nbbb\naaa\n', 'utf-8');
+    await expect(
+      executeEditFile({
+        path: target,
+        old_string: 'aaa',
+        new_string: 'ccc',
+      }),
+    ).rejects.toThrow('matches 2 locations');
+  });
+
+  it('replaces all occurrences with replace_all: true', async () => {
+    const target = join(tmpDir, 'replaceall.txt');
+    await writeFile(target, 'aaa\nbbb\naaa\nccc\naaa\n', 'utf-8');
+    const result = await executeEditFile({
+      path: target,
+      old_string: 'aaa',
+      new_string: 'zzz',
+      replace_all: true,
+    });
+    expect(result).toContain('replaced 3 occurrence');
+    const content = await readFile(target, 'utf-8');
+    expect(content).toBe('zzz\nbbb\nzzz\nccc\nzzz\n');
+  });
+
+  it('handles multi-line old_string', async () => {
+    const target = join(tmpDir, 'multiline.txt');
+    await writeFile(target, 'start\nfoo\nbar\nend\n', 'utf-8');
+    await executeEditFile({
+      path: target,
+      old_string: 'foo\nbar',
+      new_string: 'replaced',
+    });
+    const content = await readFile(target, 'utf-8');
+    expect(content).toBe('start\nreplaced\nend\n');
+  });
+
+  it('throws for a nonexistent file', async () => {
+    await expect(
+      executeEditFile({
+        path: join(tmpDir, 'nope.txt'),
+        old_string: 'x',
+        new_string: 'y',
+      }),
+    ).rejects.toThrow('Failed to read file');
+  });
+
+  it('reports line count changes', async () => {
+    const target = join(tmpDir, 'lines.txt');
+    await writeFile(target, 'one\ntwo\nthree\n', 'utf-8');
+    const result = await executeEditFile({
+      path: target,
+      old_string: 'two',
+      new_string: 'two-a\ntwo-b\ntwo-c',
+    });
+    expect(result).toContain('+2 lines');
   });
 });
 


### PR DESCRIPTION
## Summary

Implements issue #18 — adds a new `edit_file` tool that performs surgical, in-place string replacements instead of rewriting entire files via `write_file`.

- **New tool**: `edit_file` with parameters `path`, `old_string`, `new_string`, `replace_all`
- Fails with clear error if `old_string` is not found or matches multiple locations (unless `replace_all: true`)
- Returns a diff preview showing the change context
- Shares the same write-path safety analysis as `write_file` (blocked/destructive path checks)
- Added to `DANGEROUS_TOOLS` — requires `--allow-write` or interactive permission
- `--allow-write` "always" approval covers both `write_file` and `edit_file`

## Files changed (8)

| File | Change |
|---|---|
| `src/tools/editFile.ts` | **New** — core implementation with `EditFileArgs` and `executeEditFile()` |
| `src/tools/schema.ts` | Add `EDIT_FILE_TOOL` definition, update `getAllTools()` (now returns 4 tools) |
| `src/tools/index.ts` | Add `edit_file` case to `executeTool()` dispatcher |
| `src/core/agent.ts` | Add `edit_file` to `DANGEROUS_TOOLS` set |
| `src/ui/permissions.ts` | Share `write_file` safety logic with `edit_file` |
| `src/ui/format.ts` | Add `edit_file` display cases (start, result, permission) |
| `test/tools.test.ts` | 8 new tests: single replace, multi replace, not found, multi-match error, replace_all, multi-line, nonexistent file, line count changes |
| `docs/guide/tools.md` | Document `edit_file` tool with parameters and examples |

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm format:check` passes
- [x] `pnpm test` — 104/104 tests pass (8 new)
- [x] Secret scan clean — no keys, org identifiers, or sensitive data

Closes #18

Made with [Cursor](https://cursor.com)