### PR TITLE
Amazon Bedrock AgentCore Provider Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ coverage/
 *.tsbuildinfo
 docs/.vitepress/dist/
 docs/.vitepress/cache/
+pnpm-workspace.yaml
 
 # IDE
 .vscode/

--- a/README.md
+++ b/README.md
@@ -169,9 +169,10 @@ CaretForge supports multiple providers through a pluggable interface:
 
 | Provider          | Models                    | Status    |
 | ----------------- | ------------------------- | --------- |
-| `azure-anthropic` | Claude Opus, Sonnet, etc. | **Ready** |
-| `azure-foundry`   | GPT-4o, GPT-4.1, etc.     | **Ready** |
-| `azure-agents`    | Azure AI Agent Service    | Preview   |
+| `azure-anthropic`      | Claude Opus, Sonnet, etc. | **Ready** |
+| `azure-foundry`        | GPT-4o, GPT-4.1, etc.     | **Ready** |
+| `aws-bedrock-agent-core` | Amazon Bedrock Agents     | **Ready** |
+| `azure-agents`         | Azure AI Agent Service    | Preview   |
 
 ### Adding a New Provider
 

--- a/README.md
+++ b/README.md
@@ -167,12 +167,12 @@ caretforge run "List all TODO comments" --json
 
 CaretForge supports multiple providers through a pluggable interface:
 
-| Provider          | Models                    | Status    |
-| ----------------- | ------------------------- | --------- |
-| `azure-anthropic`      | Claude Opus, Sonnet, etc. | **Ready** |
-| `azure-foundry`        | GPT-4o, GPT-4.1, etc.     | **Ready** |
+| Provider                 | Models                    | Status    |
+| ------------------------ | ------------------------- | --------- |
+| `azure-anthropic`        | Claude Opus, Sonnet, etc. | **Ready** |
+| `azure-foundry`          | GPT-4o, GPT-4.1, etc.     | **Ready** |
 | `aws-bedrock-agent-core` | Amazon Bedrock Agents     | **Ready** |
-| `azure-agents`         | Azure AI Agent Service    | Preview   |
+| `azure-agents`           | Azure AI Agent Service    | Preview   |
 
 ### Adding a New Provider
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
         text: 'Guide',
         items: [
           { text: 'Azure AI Foundry Setup', link: '/guide/azure-setup' },
+          { text: 'AWS Bedrock Agent Setup', link: '/guide/aws-setup' },
           { text: 'Tools & Permissions', link: '/guide/tools' },
           { text: 'Adding a Provider', link: '/guide/adding-providers' },
           { text: 'Architecture', link: '/guide/architecture' },

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -129,15 +129,15 @@ Example:
 
 Environment variables override config file values:
 
-| Variable                      | Maps to                           |
-| ----------------------------- | --------------------------------- |
-| `CARETFORGE_DEFAULT_PROVIDER` | `defaultProvider`                 |
-| `CARETFORGE_AZURE_ENDPOINT`   | `providers.azureFoundry.endpoint` |
-| `CARETFORGE_AZURE_API_KEY`    | `providers.azureFoundry.apiKey`   |
-| `CARETFORGE_AZURE_AUTH_MODE`  | `providers.azureFoundry.authMode` |
-| `CARETFORGE_AGENT_API_KEY`    | `providers.azureAgents.apiKey`    |
-| `CARETFORGE_AWS_REGION`       | `providers.awsBedrockAgentCore.region` |
-| `CARETFORGE_AWS_AGENT_ARN`    | `providers.awsBedrockAgentCore.agentRuntimeArn` |
+| Variable                      | Maps to                                           |
+| ----------------------------- | ------------------------------------------------- |
+| `CARETFORGE_DEFAULT_PROVIDER` | `defaultProvider`                                 |
+| `CARETFORGE_AZURE_ENDPOINT`   | `providers.azureFoundry.endpoint`                 |
+| `CARETFORGE_AZURE_API_KEY`    | `providers.azureFoundry.apiKey`                   |
+| `CARETFORGE_AZURE_AUTH_MODE`  | `providers.azureFoundry.authMode`                 |
+| `CARETFORGE_AGENT_API_KEY`    | `providers.azureAgents.apiKey`                    |
+| `CARETFORGE_AWS_REGION`       | `providers.awsBedrockAgentCore.region`            |
+| `CARETFORGE_AWS_AGENT_ARN`    | `providers.awsBedrockAgentCore.agentRuntimeArn`   |
 | `AWS_REGION`                  | `providers.awsBedrockAgentCore.region` (Fallback) |
 
 ## Viewing Your Config

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -42,6 +42,11 @@ caretforge config init --with-secrets
       "models": [{ "id": "gpt-4o", "description": "GPT-4o" }],
       "chatCompletionPath": "/chat/completions",
       "apiVersion": "2024-10-21"
+    },
+    "awsBedrockAgentCore": {
+      "region": "us-east-1",
+      "agentRuntimeArn": "arn:aws:bedrock:us-east-1:123456789012:agent-alias/AGENT_ID/ALIAS_ID",
+      "profile": "default"
     }
   },
   "telemetry": false
@@ -78,6 +83,33 @@ For Anthropic models (Claude) deployed on Azure AI Foundry.
 | `apiVersion` | `string` | `"2023-06-01"` | Anthropic API version header                                |
 | `models`     | `array`  | `[]`           | List of `{ id, description? }` objects                      |
 
+### AWS Bedrock Agent Core Provider Fields
+
+For Amazon Bedrock Agents.
+
+| Field             | Type     | Default | Description                                             |
+| ----------------- | -------- | ------- | ------------------------------------------------------- |
+| `region`          | `string` | —       | **Required.** AWS region (e.g. `us-east-1`)             |
+| `agentRuntimeArn` | `string` | —       | **Required.** Full ARN of the Agent Alias               |
+| `accessKeyId`     | `string` | —       | Optional. Static AWS Access Key                         |
+| `secretAccessKey` | `string` | —       | Optional. Static AWS Secret Key                         |
+| `sessionToken`    | `string` | —       | Optional. AWS Session Token                             |
+| `profile`         | `string` | —       | Optional. AWS profile name to use from credentials file |
+
+Example:
+
+```json
+{
+  "defaultProvider": "aws-bedrock-agent-core",
+  "providers": {
+    "awsBedrockAgentCore": {
+      "region": "us-east-1",
+      "agentRuntimeArn": "arn:aws:bedrock:us-east-1:123456789012:agent-alias/AGENT_ID/ALIAS_ID"
+    }
+  }
+}
+```
+
 Example:
 
 ```json
@@ -103,9 +135,10 @@ Environment variables override config file values:
 | `CARETFORGE_AZURE_ENDPOINT`   | `providers.azureFoundry.endpoint` |
 | `CARETFORGE_AZURE_API_KEY`    | `providers.azureFoundry.apiKey`   |
 | `CARETFORGE_AZURE_AUTH_MODE`  | `providers.azureFoundry.authMode` |
-| `CARETFORGE_AGENT_ENDPOINT`   | `providers.azureAgents.endpoint`  |
-| `CARETFORGE_AGENT_ID`         | `providers.azureAgents.agentId`   |
 | `CARETFORGE_AGENT_API_KEY`    | `providers.azureAgents.apiKey`    |
+| `CARETFORGE_AWS_REGION`       | `providers.awsBedrockAgentCore.region` |
+| `CARETFORGE_AWS_AGENT_ARN`    | `providers.awsBedrockAgentCore.agentRuntimeArn` |
+| `AWS_REGION`                  | `providers.awsBedrockAgentCore.region` (Fallback) |
 
 ## Viewing Your Config
 

--- a/docs/guide/aws-setup.md
+++ b/docs/guide/aws-setup.md
@@ -26,12 +26,12 @@ arn:aws:bedrock:us-east-1:123456789012:agent-alias/AGENT_ID/ALIAS_ID
 
 CaretForge uses the standard AWS SDK credential chain. You can authenticate using any of the following methods:
 
-| Method | Configuration |
-| :--- | :--- |
+| Method                  | Configuration                                                                            |
+| :---------------------- | :--------------------------------------------------------------------------------------- |
 | **Access Key + Secret** | Direct credentials via config or env vars (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) |
-| **AWS CLI Profile** | Use `aws configure` or SSO, then set the `profile` field in config |
-| **IAM Role** | Automatic via Instance Profile or Assumed Role (e.g. on EC2/ECS) |
-| **Environment** | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` |
+| **AWS CLI Profile**     | Use `aws configure` or SSO, then set the `profile` field in config                       |
+| **IAM Role**            | Automatic via Instance Profile or Assumed Role (e.g. on EC2/ECS)                         |
+| **Environment**         | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`                        |
 
 ## Step 3: Configure CaretForge
 
@@ -86,6 +86,7 @@ CaretForge automatically handles session management with Bedrock Agents. Every t
 ## Sig V4 Signing
 
 CaretForge uses the standard AWS SDK for JavaScript (v3) to handle Signature Version 4 (Sig V4) signing. It will automatically look for credentials in:
+
 1. The `config.json` file (`accessKeyId`, `secretAccessKey`)
 2. Environment variables (`AWS_ACCESS_KEY_ID`, etc.)
 3. The specified AWS profile
@@ -94,11 +95,14 @@ CaretForge uses the standard AWS SDK for JavaScript (v3) to handle Signature Ver
 ## Troubleshooting
 
 ### "Invalid Agent Runtime ARN"
+
 - Verify the ARN copied from the AWS console matches the format `arn:aws:bedrock:REGION:ACCOUNT:agent-alias/ID/ALIAS`.
 
 ### Access Denied
+
 - Ensure your IAM user or role has the `bedrock:InvokeAgent` permission for the specific agent resource.
 - Check if the agent is in the `PREPARED` state in the AWS console.
 
 ### Region Mismatch
+
 - Ensure the `region` in your config matches the region where the Bedrock Agent is deployed.

--- a/docs/guide/aws-setup.md
+++ b/docs/guide/aws-setup.md
@@ -24,23 +24,14 @@ arn:aws:bedrock:us-east-1:123456789012:agent-alias/AGENT_ID/ALIAS_ID
 
 ## Step 2: Configure Credentials
 
-CaretForge supports several ways to authenticate with AWS:
+CaretForge uses the standard AWS SDK credential chain. You can authenticate using any of the following methods:
 
-### Option A: Environment Variables (Static)
-
-```bash
-export AWS_ACCESS_KEY_ID="your-access-key"
-export AWS_SECRET_ACCESS_KEY="your-secret-key"
-export AWS_REGION="us-east-1"
-```
-
-### Option B: AWS Profile
-
-If you use `aws configure`, you can point CaretForge to a specific profile:
-
-```bash
-export AWS_PROFILE="my-profile"
-```
+| Method | Configuration |
+| :--- | :--- |
+| **Access Key + Secret** | Direct credentials via config or env vars (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) |
+| **AWS CLI Profile** | Use `aws configure` or SSO, then set the `profile` field in config |
+| **IAM Role** | Automatic via Instance Profile or Assumed Role (e.g. on EC2/ECS) |
+| **Environment** | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` |
 
 ## Step 3: Configure CaretForge
 

--- a/docs/guide/aws-setup.md
+++ b/docs/guide/aws-setup.md
@@ -1,0 +1,113 @@
+# AWS Bedrock Agent Setup
+
+This guide walks you through setting up CaretForge with Amazon Bedrock AgentCore step by step.
+
+## Prerequisites
+
+- An [AWS account](https://aws.amazon.com/free/) with an active subscription
+- Amazon Bedrock access enabled for your region
+- A Bedrock Agent created and an Alias deployed
+
+## Step 1: Get Your Agent Runtime ARN
+
+You need the ARN for the Agent Alias you want to invoke:
+
+1. Go to the [Amazon Bedrock Console](https://console.aws.amazon.com/bedrock/)
+2. Select **Agents** from the left navigation
+3. Click on your Agent's name
+4. Scroll down to the **Aliases** section
+5. Copy the **ARN** for the alias you want to use. It looks like:
+
+```
+arn:aws:bedrock:us-east-1:123456789012:agent-alias/AGENT_ID/ALIAS_ID
+```
+
+## Step 2: Configure Credentials
+
+CaretForge supports several ways to authenticate with AWS:
+
+### Option A: Environment Variables (Static)
+
+```bash
+export AWS_ACCESS_KEY_ID="your-access-key"
+export AWS_SECRET_ACCESS_KEY="your-secret-key"
+export AWS_REGION="us-east-1"
+```
+
+### Option B: AWS Profile
+
+If you use `aws configure`, you can point CaretForge to a specific profile:
+
+```bash
+export AWS_PROFILE="my-profile"
+```
+
+## Step 3: Configure CaretForge
+
+### Option A: Config File
+
+Run the config initializer:
+
+```bash
+caretforge config init --with-secrets
+```
+
+Then edit `~/.config/caretforge/config.json`:
+
+```json
+{
+  "defaultProvider": "aws-bedrock-agent-core",
+  "providers": {
+    "awsBedrockAgentCore": {
+      "region": "us-east-1",
+      "agentRuntimeArn": "arn:aws:bedrock:us-east-1:123456789012:agent-alias/AGENT_ID/ALIAS_ID",
+      "profile": "default"
+    }
+  }
+}
+```
+
+### Option B: Environment Variables (CaretForge specific)
+
+CaretForge also looks for provider-specific environment variables:
+
+```bash
+export CARETFORGE_AWS_REGION="us-east-1"
+export CARETFORGE_AWS_AGENT_ARN="arn:aws:bedrock:us-east-1:123456789012:agent-alias/AGENT_ID/ALIAS_ID"
+```
+
+## Step 4: Validate
+
+```bash
+caretforge doctor
+```
+
+All checks should pass. Then test a request:
+
+```bash
+caretforge run "What can you do?" --provider aws-bedrock-agent-core
+```
+
+## Session Management
+
+CaretForge automatically handles session management with Bedrock Agents. Every time you start a conversation, a deterministic `sessionId` is generated (SHA-256 hash of your ARN and timestamp) to provide a unique context for that run.
+
+## Sig V4 Signing
+
+CaretForge uses the standard AWS SDK for JavaScript (v3) to handle Signature Version 4 (Sig V4) signing. It will automatically look for credentials in:
+1. The `config.json` file (`accessKeyId`, `secretAccessKey`)
+2. Environment variables (`AWS_ACCESS_KEY_ID`, etc.)
+3. The specified AWS profile
+4. The default SDK credential provider chain (IAM roles, container credentials, etc.)
+
+## Troubleshooting
+
+### "Invalid Agent Runtime ARN"
+- Verify the ARN copied from the AWS console matches the format `arn:aws:bedrock:REGION:ACCOUNT:agent-alias/ID/ALIAS`.
+
+### Access Denied
+- Ensure your IAM user or role has the `bedrock:InvokeAgent` permission for the specific agent resource.
+- Check if the agent is in the `PREPARED` state in the AWS console.
+
+### Region Mismatch
+- Ensure the `region` in your config matches the region where the Bedrock Agent is deployed.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -115,18 +115,19 @@ Path: `providers.awsBedrockAgentCore`
 
 For Amazon Bedrock Agents (InvokeAgent API).
 
-| Field             | Type     | Required | Default | Description                                             |
-| ----------------- | -------- | -------- | ------- | ------------------------------------------------------- |
-| `region`          | `string` | Yes      | —       | AWS region (e.g. `us-east-1`)                           |
-| `agentRuntimeArn` | `string` | Yes      | —       | Full ARN of the Agent Alias                             |
-| `accessKeyId`     | `string` | No       | —       | Static AWS Access Key                                   |
-| `secretAccessKey` | `string` | No       | —       | Static AWS Secret Key                                   |
-| `sessionToken`    | `string` | No       | —       | AWS Session Token                                       |
-| `profile`         | `string` | No       | —       | AWS profile name to use from credentials file           |
+| Field             | Type     | Required | Default | Description                                   |
+| ----------------- | -------- | -------- | ------- | --------------------------------------------- |
+| `region`          | `string` | Yes      | —       | AWS region (e.g. `us-east-1`)                 |
+| `agentRuntimeArn` | `string` | Yes      | —       | Full ARN of the Agent Alias                   |
+| `accessKeyId`     | `string` | No       | —       | Static AWS Access Key                         |
+| `secretAccessKey` | `string` | No       | —       | Static AWS Secret Key                         |
+| `sessionToken`    | `string` | No       | —       | AWS Session Token                             |
+| `profile`         | `string` | No       | —       | AWS profile name to use from credentials file |
 
 ### Credentials Resolution
 
 CaretForge follows the standard AWS credential provider chain order:
+
 1. Static credentials in `config.json`
 2. Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`)
 3. AWS profile specified in `config.json`

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -26,6 +26,11 @@ Complete reference for the `config.json` file.
       "endpoint": "https://RESOURCE.openai.azure.com/anthropic",
       "apiKey": "your-api-key",
       "models": [{ "id": "claude-opus-4-6", "description": "Claude Opus 4-6" }]
+    },
+    "awsBedrockAgentCore": {
+      "region": "us-east-1",
+      "agentRuntimeArn": "arn:aws:bedrock:us-east-1:123456789012:agent-alias/AGENT_ID/ALIAS_ID",
+      "profile": "default"
     }
   },
   "telemetry": false
@@ -38,7 +43,7 @@ Complete reference for the `config.json` file.
 
 - **Type:** `string`
 - **Default:** `"azure-foundry"`
-- **Values:** `"azure-foundry"`, `"azure-agents"`, `"azure-anthropic"`
+- **Values:** `"azure-foundry"`, `"azure-agents"`, `"azure-anthropic"`, `"aws-bedrock-agent-core"`
 
 The provider used when `--provider` is not specified on the command line.
 
@@ -103,6 +108,29 @@ For Anthropic models (Claude) deployed on Azure AI Foundry. Uses the Anthropic M
 ```
 
 Uses the `x-api-key` header for authentication and `anthropic-version` header for API versioning.
+
+## AWS Bedrock Agent Core Provider
+
+Path: `providers.awsBedrockAgentCore`
+
+For Amazon Bedrock Agents (InvokeAgent API).
+
+| Field             | Type     | Required | Default | Description                                             |
+| ----------------- | -------- | -------- | ------- | ------------------------------------------------------- |
+| `region`          | `string` | Yes      | —       | AWS region (e.g. `us-east-1`)                           |
+| `agentRuntimeArn` | `string` | Yes      | —       | Full ARN of the Agent Alias                             |
+| `accessKeyId`     | `string` | No       | —       | Static AWS Access Key                                   |
+| `secretAccessKey` | `string` | No       | —       | Static AWS Secret Key                                   |
+| `sessionToken`    | `string` | No       | —       | AWS Session Token                                       |
+| `profile`         | `string` | No       | —       | AWS profile name to use from credentials file           |
+
+### Credentials Resolution
+
+CaretForge follows the standard AWS credential provider chain order:
+1. Static credentials in `config.json`
+2. Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`)
+3. AWS profile specified in `config.json`
+4. Default credential chain (shared config file, IAM roles, etc.)
 
 ## Validation
 

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -24,6 +24,17 @@ All environment variables are optional and override their corresponding config f
 | `CARETFORGE_AGENT_ID`       | `providers.azureAgents.agentId`  | Agent ID               |
 | `CARETFORGE_AGENT_API_KEY`  | `providers.azureAgents.apiKey`   | API key (optional)     |
 
+## AWS Bedrock Agent Core
+
+| Variable                   | Config Path                                     | Description                       |
+| -------------------------- | ----------------------------------------------- | --------------------------------- |
+| `CARETFORGE_AWS_REGION`    | `providers.awsBedrockAgentCore.region`          | AWS region (e.g. `us-east-1`)     |
+| `CARETFORGE_AWS_AGENT_ARN` | `providers.awsBedrockAgentCore.agentRuntimeArn` | Full ARN of the Agent Alias       |
+| `AWS_REGION`               | `providers.awsBedrockAgentCore.region`          | Fallback for region               |
+| `AWS_ACCESS_KEY_ID`        | N/A (AWS SDK)                                   | Standard AWS Access Key           |
+| `AWS_SECRET_ACCESS_KEY`    | N/A (AWS SDK)                                   | Standard AWS Secret Key           |
+| `AWS_PROFILE`              | N/A (AWS SDK)                                   | AWS profile name                  |
+
 ## Other
 
 | Variable          | Description                                                |

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -26,14 +26,14 @@ All environment variables are optional and override their corresponding config f
 
 ## AWS Bedrock Agent Core
 
-| Variable                   | Config Path                                     | Description                       |
-| -------------------------- | ----------------------------------------------- | --------------------------------- |
-| `CARETFORGE_AWS_REGION`    | `providers.awsBedrockAgentCore.region`          | AWS region (e.g. `us-east-1`)     |
-| `CARETFORGE_AWS_AGENT_ARN` | `providers.awsBedrockAgentCore.agentRuntimeArn` | Full ARN of the Agent Alias       |
-| `AWS_REGION`               | `providers.awsBedrockAgentCore.region`          | Fallback for region               |
-| `AWS_ACCESS_KEY_ID`        | N/A (AWS SDK)                                   | Standard AWS Access Key           |
-| `AWS_SECRET_ACCESS_KEY`    | N/A (AWS SDK)                                   | Standard AWS Secret Key           |
-| `AWS_PROFILE`              | N/A (AWS SDK)                                   | AWS profile name                  |
+| Variable                   | Config Path                                     | Description                   |
+| -------------------------- | ----------------------------------------------- | ----------------------------- |
+| `CARETFORGE_AWS_REGION`    | `providers.awsBedrockAgentCore.region`          | AWS region (e.g. `us-east-1`) |
+| `CARETFORGE_AWS_AGENT_ARN` | `providers.awsBedrockAgentCore.agentRuntimeArn` | Full ARN of the Agent Alias   |
+| `AWS_REGION`               | `providers.awsBedrockAgentCore.region`          | Fallback for region           |
+| `AWS_ACCESS_KEY_ID`        | N/A (AWS SDK)                                   | Standard AWS Access Key       |
+| `AWS_SECRET_ACCESS_KEY`    | N/A (AWS SDK)                                   | Standard AWS Secret Key       |
+| `AWS_PROFILE`              | N/A (AWS SDK)                                   | AWS profile name              |
 
 ## Other
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@aws-sdk/client-bedrock-agent-runtime": "^3.987.0",
     "chalk": "^5.4.1",
     "commander": "^12.1.0",
     "ora": "^8.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@aws-sdk/client-bedrock-agent-runtime':
+        specifier: ^3.987.0
+        version: 3.987.0
       chalk:
         specifier: ^5.4.1
         version: 5.6.2
@@ -132,6 +135,131 @@ packages:
   '@algolia/requester-node-http@5.48.0':
     resolution: {integrity: sha512-ZgxV2+5qt3NLeUYBTsi6PLyHcENQWC0iFppFZekHSEDA2wcLdTUjnaJzimTEULHIvJuLRCkUs4JABdhuJktEag==}
     engines: {node: '>= 14.0.0'}
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-bedrock-agent-runtime@3.987.0':
+    resolution: {integrity: sha512-xarIea99LTwgeQ6vwH4qrlh3O+qNCEpdyREM3uuT0lVQzMcVoC6b0muTCmX4uGBpYSkO5fNXyABiwRtQ8YAZGA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-sso@3.985.0':
+    resolution: {integrity: sha512-81J8iE8MuXhdbMfIz4sWFj64Pe41bFi/uqqmqOC5SlGv+kwoyLsyKS/rH2tW2t5buih4vTUxskRjxlqikTD4oQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.973.7':
+    resolution: {integrity: sha512-wNZZQQNlJ+hzD49cKdo+PY6rsTDElO8yDImnrI69p2PLBa7QomeUKAJWYp9xnaR38nlHqWhMHZuYLCQ3oSX+xg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.5':
+    resolution: {integrity: sha512-LxJ9PEO4gKPXzkufvIESUysykPIdrV7+Ocb9yAhbhJLE4TiAYqbCVUE+VuKP1leGR1bBfjWjYgSV5MxprlX3mQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.7':
+    resolution: {integrity: sha512-L2uOGtvp2x3bTcxFTpSM+GkwFIPd8pHfGWO1764icMbo7e5xJh0nfhx1UwkXLnwvocTNEf8A7jISZLYjUSNaTg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.5':
+    resolution: {integrity: sha512-SdDTYE6jkARzOeL7+kudMIM4DaFnP5dZVeatzw849k4bSXDdErDS188bgeNzc/RA2WGrlEpsqHUKP6G7sVXhZg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.5':
+    resolution: {integrity: sha512-uYq1ILyTSI6ZDCMY5+vUsRM0SOCVI7kaW4wBrehVVkhAxC6y+e9rvGtnoZqCOWL1gKjTMouvsf4Ilhc5NCg1Aw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.6':
+    resolution: {integrity: sha512-DZ3CnAAtSVtVz+G+ogqecaErMLgzph4JH5nYbHoBMgBkwTUV+SUcjsjOJwdBJTHu3Dm6l5LBYekZoU2nDqQk2A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.5':
+    resolution: {integrity: sha512-HDKF3mVbLnuqGg6dMnzBf1VUOywE12/N286msI9YaK9mEIzdsGCtLTvrDhe3Up0R9/hGFbB+9l21/TwF5L1C6g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.5':
+    resolution: {integrity: sha512-8urj3AoeNeQisjMmMBhFeiY2gxt6/7wQQbEGun0YV/OaOOiXrIudTIEYF8ZfD+NQI6X1FY5AkRsx6O/CaGiybA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.5':
+    resolution: {integrity: sha512-OK3cULuJl6c+RcDZfPpaK5o3deTOnKZbxm7pzhFNGA3fI2hF9yDih17fGRazJzGGWaDVlR9ejZrpDef4DJCEsw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-host-header@3.972.3':
+    resolution: {integrity: sha512-aknPTb2M+G3s+0qLCx4Li/qGZH8IIYjugHMv15JTYMe6mgZO8VBpYgeGYsNMGCqCZOcWzuf900jFBG5bopfzmA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-logger@3.972.3':
+    resolution: {integrity: sha512-Ftg09xNNRqaz9QNzlfdQWfpqMCJbsQdnZVJP55jfhbKi1+FTWxGuvfPoBhDHIovqWKjqbuiew3HuhxbJ0+OjgA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.3':
+    resolution: {integrity: sha512-PY57QhzNuXHnwbJgbWYTrqIDHYSeOlhfYERTAuc16LKZpTZRJUjzBFokp9hF7u1fuGeE3D70ERXzdbMBOqQz7Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.972.7':
+    resolution: {integrity: sha512-HUD+geASjXSCyL/DHPQc/Ua7JhldTcIglVAoCV8kiVm99IaFSlAbTvEnyhZwdE6bdFyTL+uIaWLaCFSRsglZBQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.985.0':
+    resolution: {integrity: sha512-TsWwKzb/2WHafAY0CE7uXgLj0FmnkBTgfioG9HO+7z/zCPcl1+YU+i7dW4o0y+aFxFgxTMG+ExBQpqT/k2ao8g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.3':
+    resolution: {integrity: sha512-v4J8qYAWfOMcZ4MJUyatntOicTzEMaU7j3OpkRCGGFSL2NgXQ5VbxauIyORA+pxdKZ0qQG2tCQjQjZDlXEC3Ow==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.985.0':
+    resolution: {integrity: sha512-+hwpHZyEq8k+9JL2PkE60V93v2kNhUIv7STFt+EAez1UJsJOQDhc5LpzEX66pNjclI5OTwBROs/DhJjC/BtMjQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.1':
+    resolution: {integrity: sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.985.0':
+    resolution: {integrity: sha512-vth7UfGSUR3ljvaq8V4Rc62FsM7GUTH/myxPWkaEgOrprz1/Pc72EgTXxj+cPPPDAfHFIpjhkB7T7Td0RJx+BA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.987.0':
+    resolution: {integrity: sha512-rZnZwDq7Pn+TnL0nyS6ryAhpqTZtLtHbJaqfxuHlDX3v/bq0M7Ch/V3qF9dZWaGgsJ2H9xn7/vFOxlnL4fBMcQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.4':
+    resolution: {integrity: sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-user-agent-browser@3.972.3':
+    resolution: {integrity: sha512-JurOwkRUcXD/5MTDBcqdyQ9eVedtAsZgw5rBwktsPTN7QtPiS2Ld1jkJepNgYoCufz1Wcut9iup7GJDoIHp8Fw==}
+
+  '@aws-sdk/util-user-agent-node@3.972.5':
+    resolution: {integrity: sha512-GsUDF+rXyxDZkkJxUsDxnA67FG+kc5W1dnloCFLl6fWzceevsCYzJpASBzT+BPjwUgREE6FngfJYYYMQUY5fZQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/xml-builder@3.972.4':
+    resolution: {integrity: sha512-0zJ05ANfYqI6+rGqj8samZBFod0dPPousBjLEqg8WdxSgbMAkRgLyn81lP215Do0rFJ/17LIXwr7q0yK24mP6Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.3':
+    resolution: {integrity: sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -539,6 +667,198 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@smithy/abort-controller@4.2.8':
+    resolution: {integrity: sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/config-resolver@4.4.6':
+    resolution: {integrity: sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.23.0':
+    resolution: {integrity: sha512-Yq4UPVoQICM9zHnByLmG8632t2M0+yap4T7ANVw482J0W7HW0pOuxwVmeOwzJqX2Q89fkXz0Vybz55Wj2Xzrsg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.2.8':
+    resolution: {integrity: sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-codec@4.2.8':
+    resolution: {integrity: sha512-jS/O5Q14UsufqoGhov7dHLOPCzkYJl9QDzusI2Psh4wyYx/izhzvX9P4D69aTxcdfVhEPhjK+wYyn/PzLjKbbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-browser@4.2.8':
+    resolution: {integrity: sha512-MTfQT/CRQz5g24ayXdjg53V0mhucZth4PESoA5IhvaWVDTOQLfo8qI9vzqHcPsdd2v6sqfTYqF5L/l+pea5Uyw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-config-resolver@4.3.8':
+    resolution: {integrity: sha512-ah12+luBiDGzBruhu3efNy1IlbwSEdNiw8fOZksoKoWW1ZHvO/04MQsdnws/9Aj+5b0YXSSN2JXKy/ClIsW8MQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-node@4.2.8':
+    resolution: {integrity: sha512-cYpCpp29z6EJHa5T9WL0KAlq3SOKUQkcgSoeRfRVwjGgSFl7Uh32eYGt7IDYCX20skiEdRffyDpvF2efEZPC0A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-universal@4.2.8':
+    resolution: {integrity: sha512-iJ6YNJd0bntJYnX6s52NC4WFYcZeKrPUr1Kmmr5AwZcwCSzVpS7oavAmxMR7pMq7V+D1G4s9F5NJK0xwOsKAlQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.3.9':
+    resolution: {integrity: sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-node@4.2.8':
+    resolution: {integrity: sha512-7ZIlPbmaDGxVoxErDZnuFG18WekhbA/g2/i97wGj+wUBeS6pcUeAym8u4BXh/75RXWhgIJhyC11hBzig6MljwA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.2.8':
+    resolution: {integrity: sha512-N9iozRybwAQ2dn9Fot9kI6/w9vos2oTXLhtK7ovGqwZjlOcxu6XhPlpLpC+INsxktqHinn5gS2DXDjDF2kG5sQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/is-array-buffer@4.2.0':
+    resolution: {integrity: sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-content-length@4.2.8':
+    resolution: {integrity: sha512-RO0jeoaYAB1qBRhfVyq0pMgBoUK34YEJxVxyjOWYZiOKOq2yMZ4MnVXMZCUDenpozHue207+9P5ilTV1zeda0A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.4.14':
+    resolution: {integrity: sha512-FUFNE5KVeaY6U/GL0nzAAHkaCHzXLZcY1EhtQnsAqhD8Du13oPKtMB9/0WK4/LK6a/T5OZ24wPoSShff5iI6Ag==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-retry@4.4.31':
+    resolution: {integrity: sha512-RXBzLpMkIrxBPe4C8OmEOHvS8aH9RUuCOH++Acb5jZDEblxDjyg6un72X9IcbrGTJoiUwmI7hLypNfuDACypbg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.2.9':
+    resolution: {integrity: sha512-eMNiej0u/snzDvlqRGSN3Vl0ESn3838+nKyVfF2FKNXFbi4SERYT6PR392D39iczngbqqGG0Jl1DlCnp7tBbXQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-stack@4.2.8':
+    resolution: {integrity: sha512-w6LCfOviTYQjBctOKSwy6A8FIkQy7ICvglrZFl6Bw4FmcQ1Z420fUtIhxaUZZshRe0VCq4kvDiPiXrPZAe8oRA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.3.8':
+    resolution: {integrity: sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.4.10':
+    resolution: {integrity: sha512-u4YeUwOWRZaHbWaebvrs3UhwQwj+2VNmcVCwXcYTvPIuVyM7Ex1ftAj+fdbG/P4AkBwLq/+SKn+ydOI4ZJE9PA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.2.8':
+    resolution: {integrity: sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/protocol-http@5.3.8':
+    resolution: {integrity: sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-builder@4.2.8':
+    resolution: {integrity: sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-parser@4.2.8':
+    resolution: {integrity: sha512-vUurovluVy50CUlazOiXkPq40KGvGWSdmusa3130MwrR1UNnNgKAlj58wlOe61XSHRpUfIIh6cE0zZ8mzKaDPA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/service-error-classification@4.2.8':
+    resolution: {integrity: sha512-mZ5xddodpJhEt3RkCjbmUQuXUOaPNTkbMGR0bcS8FE0bJDLMZlhmpgrvPNCYglVw5rsYTpSnv19womw9WWXKQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/shared-ini-file-loader@4.4.3':
+    resolution: {integrity: sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.3.8':
+    resolution: {integrity: sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.11.3':
+    resolution: {integrity: sha512-Q7kY5sDau8OoE6Y9zJoRGgje8P4/UY0WzH8R2ok0PDh+iJ+ZnEKowhjEqYafVcubkbYxQVaqwm3iufktzhprGg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.12.0':
+    resolution: {integrity: sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.2.8':
+    resolution: {integrity: sha512-NQho9U68TGMEU639YkXnVMV3GEFFULmmaWdlu1E9qzyIePOHsoSnagTGSDv1Zi8DCNN6btxOSdgmy5E/hsZwhA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-base64@4.3.0':
+    resolution: {integrity: sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-browser@4.2.0':
+    resolution: {integrity: sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-node@4.2.1':
+    resolution: {integrity: sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-buffer-from@4.2.0':
+    resolution: {integrity: sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-config-provider@4.2.0':
+    resolution: {integrity: sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-browser@4.3.30':
+    resolution: {integrity: sha512-cMni0uVU27zxOiU8TuC8pQLC1pYeZ/xEMxvchSK/ILwleRd1ugobOcIRr5vXtcRqKd4aBLWlpeBoDPJJ91LQng==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-node@4.2.33':
+    resolution: {integrity: sha512-LEb2aq5F4oZUSzWBG7S53d4UytZSkOEJPXcBq/xbG2/TmK9EW5naUZ8lKu1BEyWMzdHIzEVN16M3k8oxDq+DJA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.2.8':
+    resolution: {integrity: sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.2.0':
+    resolution: {integrity: sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-middleware@4.2.8':
+    resolution: {integrity: sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-retry@4.2.8':
+    resolution: {integrity: sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.5.12':
+    resolution: {integrity: sha512-D8tgkrmhAX/UNeCZbqbEO3uqyghUnEmmoO9YEvRuwxjlkKKUE7FOgCJnqpTlQPe9MApdWPky58mNQQHbnCzoNg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-uri-escape@4.2.0':
+    resolution: {integrity: sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@4.2.0':
+    resolution: {integrity: sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/uuid@1.1.0':
+    resolution: {integrity: sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==}
+    engines: {node: '>=18.0.0'}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -804,6 +1124,9 @@ packages:
   birpc@2.9.0:
     resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
 
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -1016,6 +1339,10 @@ packages:
 
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
+  fast-xml-parser@5.3.4:
+    resolution: {integrity: sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==}
+    hasBin: true
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1443,6 +1770,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strnum@2.1.2:
+    resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
+
   superjson@2.2.6:
     resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
     engines: {node: '>=16'}
@@ -1487,6 +1817,9 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -1752,6 +2085,390 @@ snapshots:
   '@algolia/requester-node-http@5.48.0':
     dependencies:
       '@algolia/client-common': 5.48.0
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.1
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-locate-window': 3.965.4
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.1
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-bedrock-agent-runtime@3.987.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/credential-provider-node': 3.972.6
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.7
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.987.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.5
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.0
+      '@smithy/eventstream-serde-browser': 4.2.8
+      '@smithy/eventstream-serde-config-resolver': 4.3.8
+      '@smithy/eventstream-serde-node': 4.2.8
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.14
+      '@smithy/middleware-retry': 4.4.31
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.30
+      '@smithy/util-defaults-mode-node': 4.2.33
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-sso@3.985.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.7
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.985.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.5
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.0
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.14
+      '@smithy/middleware-retry': 4.4.31
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.30
+      '@smithy/util-defaults-mode-node': 4.2.33
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/core@3.973.7':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/xml-builder': 3.972.4
+      '@smithy/core': 3.23.0
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/signature-v4': 5.3.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.5':
+    dependencies:
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.7':
+    dependencies:
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/types': 3.973.1
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      '@smithy/util-stream': 4.5.12
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.5':
+    dependencies:
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/credential-provider-env': 3.972.5
+      '@aws-sdk/credential-provider-http': 3.972.7
+      '@aws-sdk/credential-provider-login': 3.972.5
+      '@aws-sdk/credential-provider-process': 3.972.5
+      '@aws-sdk/credential-provider-sso': 3.972.5
+      '@aws-sdk/credential-provider-web-identity': 3.972.5
+      '@aws-sdk/nested-clients': 3.985.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.5':
+    dependencies:
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/nested-clients': 3.985.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-node@3.972.6':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.5
+      '@aws-sdk/credential-provider-http': 3.972.7
+      '@aws-sdk/credential-provider-ini': 3.972.5
+      '@aws-sdk/credential-provider-process': 3.972.5
+      '@aws-sdk/credential-provider-sso': 3.972.5
+      '@aws-sdk/credential-provider-web-identity': 3.972.5
+      '@aws-sdk/types': 3.973.1
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-process@3.972.5':
+    dependencies:
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.5':
+    dependencies:
+      '@aws-sdk/client-sso': 3.985.0
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/token-providers': 3.985.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.5':
+    dependencies:
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/nested-clients': 3.985.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/middleware-host-header@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-logger@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@aws/lambda-invoke-store': 0.2.3
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.7':
+    dependencies:
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.985.0
+      '@smithy/core': 3.23.0
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.985.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.7
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.985.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.5
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.0
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.14
+      '@smithy/middleware-retry': 4.4.31
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.30
+      '@smithy/util-defaults-mode-node': 4.2.33
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/region-config-resolver@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.985.0':
+    dependencies:
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/nested-clients': 3.985.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/types@3.973.1':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.985.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-endpoints': 3.2.8
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.987.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-endpoints': 3.2.8
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-node@3.972.5':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.7
+      '@aws-sdk/types': 3.973.1
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.4':
+    dependencies:
+      '@smithy/types': 4.12.0
+      fast-xml-parser: 5.3.4
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.3': {}
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -2040,6 +2757,310 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@smithy/abort-controller@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/config-resolver@4.4.6':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-config-provider': 4.2.0
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      tslib: 2.8.1
+
+  '@smithy/core@3.23.0':
+    dependencies:
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-stream': 4.5.12
+      '@smithy/util-utf8': 4.2.0
+      '@smithy/uuid': 1.1.0
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.2.8':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      tslib: 2.8.1
+
+  '@smithy/eventstream-codec@4.2.8':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.12.0
+      '@smithy/util-hex-encoding': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-browser@4.2.8':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-config-resolver@4.3.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-node@4.2.8':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-universal@4.2.8':
+    dependencies:
+      '@smithy/eventstream-codec': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.3.9':
+    dependencies:
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/querystring-builder': 4.2.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      tslib: 2.8.1
+
+  '@smithy/hash-node@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/invalid-dependency@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/middleware-content-length@4.2.8':
+    dependencies:
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.4.14':
+    dependencies:
+      '@smithy/core': 3.23.0
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-middleware': 4.2.8
+      tslib: 2.8.1
+
+  '@smithy/middleware-retry@4.4.31':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/service-error-classification': 4.2.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/uuid': 1.1.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-serde@4.2.9':
+    dependencies:
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.3.8':
+    dependencies:
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.4.10':
+    dependencies:
+      '@smithy/abort-controller': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/querystring-builder': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/property-provider@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.3.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/querystring-builder@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      '@smithy/util-uri-escape': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/querystring-parser@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/service-error-classification@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+
+  '@smithy/shared-ini-file-loader@4.4.3':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.3.8':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.0
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-hex-encoding': 4.2.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-uri-escape': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.11.3':
+    dependencies:
+      '@smithy/core': 3.23.0
+      '@smithy/middleware-endpoint': 4.4.14
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-stream': 4.5.12
+      tslib: 2.8.1
+
+  '@smithy/types@4.12.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/url-parser@4.2.8':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-base64@4.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-browser@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-node@4.2.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@4.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-config-provider@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-browser@4.3.30':
+    dependencies:
+      '@smithy/property-provider': 4.2.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-node@4.2.33':
+    dependencies:
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-endpoints@3.2.8':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-hex-encoding@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.2.8':
+    dependencies:
+      '@smithy/service-error-classification': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.5.12':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-hex-encoding': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-uri-escape@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@4.2.0':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/uuid@1.1.0':
+    dependencies:
+      tslib: 2.8.1
 
   '@types/estree@1.0.8': {}
 
@@ -2359,6 +3380,8 @@ snapshots:
 
   birpc@2.9.0: {}
 
+  bowser@2.14.1: {}
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -2579,6 +3602,10 @@ snapshots:
   fast-levenshtein@2.0.6: {}
 
   fast-safe-stringify@2.1.1: {}
+
+  fast-xml-parser@5.3.4:
+    dependencies:
+      strnum: 2.1.2
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -3018,6 +4045,8 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strnum@2.1.2: {}
+
   superjson@2.2.6:
     dependencies:
       copy-anything: 4.0.5
@@ -3052,6 +4081,8 @@ snapshots:
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  tslib@2.8.1: {}
 
   type-check@0.4.0:
     dependencies:

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -82,6 +82,45 @@ export const doctorCommand = new Command('doctor')
             message: 'Not configured. Add providers.azureFoundry to config.',
           });
         }
+
+        // ── AWS Bedrock Agent Core checks ──────────────────
+        const aws = config.providers.awsBedrockAgentCore;
+        if (aws) {
+          checks.push({
+            name: 'AWS region',
+            status: aws.region ? 'ok' : 'fail',
+            message: aws.region || 'Region is missing.',
+          });
+
+          const hasArn = !!aws.agentRuntimeArn || !!process.env['CARETFORGE_AWS_AGENT_ARN'];
+          checks.push({
+            name: 'AWS Agent ARN',
+            status: hasArn ? (aws.agentRuntimeArn?.includes('AGENT_ID') ? 'warn' : 'ok') : 'fail',
+            message: !hasArn
+              ? 'Agent Runtime ARN is missing.'
+              : aws.agentRuntimeArn?.includes('AGENT_ID')
+                ? 'Still using placeholder ARN. Update your config.'
+                : aws.agentRuntimeArn,
+          });
+
+          const hasCreds = (!!aws.accessKeyId && !!aws.secretAccessKey) ||
+            (!!process.env['AWS_ACCESS_KEY_ID'] && !!process.env['AWS_SECRET_ACCESS_KEY']) ||
+            !!aws.profile;
+
+          checks.push({
+            name: 'AWS Credentials',
+            status: hasCreds ? 'ok' : 'warn',
+            message: hasCreds
+              ? (aws.profile ? `Using profile: ${aws.profile}` : 'Credentials found in config/env.')
+              : 'No explicit credentials found. Will use default SDK chain.',
+          });
+        } else {
+          checks.push({
+            name: 'AWS Bedrock Agent',
+            status: 'warn',
+            message: 'Not configured. Add providers.awsBedrockAgentCore to config.',
+          });
+        }
       } catch (err) {
         checks.push({
           name: 'Config valid',

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -103,7 +103,8 @@ export const doctorCommand = new Command('doctor')
                 : aws.agentRuntimeArn,
           });
 
-          const hasCreds = (!!aws.accessKeyId && !!aws.secretAccessKey) ||
+          const hasCreds =
+            (!!aws.accessKeyId && !!aws.secretAccessKey) ||
             (!!process.env['AWS_ACCESS_KEY_ID'] && !!process.env['AWS_SECRET_ACCESS_KEY']) ||
             !!aws.profile;
 
@@ -111,7 +112,9 @@ export const doctorCommand = new Command('doctor')
             name: 'AWS Credentials',
             status: hasCreds ? 'ok' : 'warn',
             message: hasCreds
-              ? (aws.profile ? `Using profile: ${aws.profile}` : 'Credentials found in config/env.')
+              ? aws.profile
+                ? `Using profile: ${aws.profile}`
+                : 'Credentials found in config/env.'
               : 'No explicit credentials found. Will use default SDK chain.',
           });
         } else {

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -1,8 +1,8 @@
 import { loadConfig } from '../config/index.js';
 import { AzureFoundryProvider } from '../providers/azureFoundry.js';
+import { AwsBedrockAgentCoreProvider } from '../providers/awsBedrockAgentCore.js';
 import { AzureAgentsProvider } from '../providers/azureAgents.js';
 import { AzureAnthropicProvider } from '../providers/azureAnthropic.js';
-import { AwsBedrockAgentCoreProvider } from '../providers/awsBedrockAgentCore.js';
 import type { Provider } from '../providers/provider.js';
 import { ConfigError } from '../util/errors.js';
 

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -2,6 +2,7 @@ import { loadConfig } from '../config/index.js';
 import { AzureFoundryProvider } from '../providers/azureFoundry.js';
 import { AzureAgentsProvider } from '../providers/azureAgents.js';
 import { AzureAnthropicProvider } from '../providers/azureAnthropic.js';
+import { AwsBedrockAgentCoreProvider } from '../providers/awsBedrockAgentCore.js';
 import type { Provider } from '../providers/provider.js';
 import { ConfigError } from '../util/errors.js';
 
@@ -44,9 +45,19 @@ export async function resolveProvider(globals: Record<string, unknown>): Promise
       return new AzureAnthropicProvider(anthropicConfig);
     }
 
+    case 'aws-bedrock-agent-core': {
+      const agentConfig = config.providers.awsBedrockAgentCore;
+      if (!agentConfig) {
+        throw new ConfigError(
+          'AWS Bedrock Agent Core provider is not configured. Add providers.awsBedrockAgentCore to config.',
+        );
+      }
+      return new AwsBedrockAgentCoreProvider(agentConfig);
+    }
+
     default:
       throw new ConfigError(
-        `Unknown provider "${providerName}". Available providers: azure-foundry, azure-agents, azure-anthropic`,
+        `Unknown provider "${providerName}". Available providers: azure-foundry, azure-agents, azure-anthropic, aws-bedrock-agent-core`,
       );
   }
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -141,25 +141,25 @@ export async function saveConfig(
   // Strip secrets unless explicitly told to keep them
   const toSave: CaretForgeConfig = !options?.withSecrets
     ? {
-      ...config,
-      providers: {
-        ...config.providers,
-        azureFoundry: config.providers.azureFoundry
-          ? {
-            ...config.providers.azureFoundry,
-            apiKey: undefined,
-          }
-          : undefined,
-        awsBedrockAgentCore: config.providers.awsBedrockAgentCore
-          ? {
-            ...config.providers.awsBedrockAgentCore,
-            accessKeyId: undefined,
-            secretAccessKey: undefined,
-            sessionToken: undefined,
-          }
-          : undefined,
-      },
-    }
+        ...config,
+        providers: {
+          ...config.providers,
+          azureFoundry: config.providers.azureFoundry
+            ? {
+                ...config.providers.azureFoundry,
+                apiKey: undefined,
+              }
+            : undefined,
+          awsBedrockAgentCore: config.providers.awsBedrockAgentCore
+            ? {
+                ...config.providers.awsBedrockAgentCore,
+                accessKeyId: undefined,
+                secretAccessKey: undefined,
+                sessionToken: undefined,
+              }
+            : undefined,
+        },
+      }
     : config;
 
   await writeFile(configPath, JSON.stringify(toSave, null, 2) + '\n', 'utf-8');

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -150,6 +150,14 @@ export async function saveConfig(
             apiKey: undefined,
           }
           : undefined,
+        awsBedrockAgentCore: config.providers.awsBedrockAgentCore
+          ? {
+            ...config.providers.awsBedrockAgentCore,
+            accessKeyId: undefined,
+            secretAccessKey: undefined,
+            sessionToken: undefined,
+          }
+          : undefined,
       },
     }
     : config;
@@ -182,6 +190,10 @@ export async function initConfig(options?: { withSecrets?: boolean }): Promise<s
         models: [{ id: 'gpt-4o', description: 'GPT-4o on Azure AI Foundry' }],
         chatCompletionPath: '/chat/completions',
         apiVersion: '2024-08-01-preview',
+      },
+      awsBedrockAgentCore: {
+        region: 'us-east-1',
+        agentRuntimeArn: 'arn:aws:bedrock:REGION:ACCOUNT:agent-alias/AGENT_ID/ALIAS_ID',
       },
     },
     telemetry: false,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -38,11 +38,22 @@ export const azureAnthropicConfigSchema = z.object({
   models: z.array(modelSchema).default([]),
 });
 
+// ── AWS Bedrock Agent Core provider config ────────────────────
+export const awsBedrockAgentCoreConfigSchema = z.object({
+  region: z.string().min(1, 'Region is required'),
+  agentRuntimeArn: z.string().min(1, 'Agent Runtime ARN is required'), // e.g. arn:aws:bedrock:us-east-1:123456789012:agent-alias/AGENT_ID/ALIAS_ID
+  accessKeyId: z.string().optional(),
+  secretAccessKey: z.string().optional(),
+  sessionToken: z.string().optional(),
+  profile: z.string().optional(),
+});
+
 // ── Top-level providers map ───────────────────────────────────
 export const providersSchema = z.object({
   azureFoundry: azureFoundryConfigSchema.optional(),
   azureAgents: azureAgentsConfigSchema.optional(),
   azureAnthropic: azureAnthropicConfigSchema.optional(),
+  awsBedrockAgentCore: awsBedrockAgentCoreConfigSchema.optional(),
 });
 
 // ── Root config ───────────────────────────────────────────────
@@ -57,5 +68,6 @@ export type CaretForgeConfig = z.infer<typeof configSchema>;
 export type AzureFoundryConfig = z.infer<typeof azureFoundryConfigSchema>;
 export type AzureAgentsConfig = z.infer<typeof azureAgentsConfigSchema>;
 export type AzureAnthropicConfig = z.infer<typeof azureAnthropicConfigSchema>;
+export type AwsBedrockAgentCoreConfig = z.infer<typeof awsBedrockAgentCoreConfigSchema>;
 export type ModelConfig = z.infer<typeof modelSchema>;
 export type ProvidersConfig = z.infer<typeof providersSchema>;

--- a/src/providers/awsBedrockAgentCore.ts
+++ b/src/providers/awsBedrockAgentCore.ts
@@ -1,15 +1,17 @@
 import {
-    BedrockAgentRuntimeClient,
-    InvokeAgentCommand,
-    InvokeAgentCommandOutput,
+  BedrockAgentRuntimeClient,
+  type BedrockAgentRuntimeClientConfig,
+  InvokeAgentCommand,
+  type InvokeAgentCommandOutput,
 } from '@aws-sdk/client-bedrock-agent-runtime';
+
 import type {
-    Provider,
-    ChatMessage,
-    ChatCompletionOptions,
-    ChatCompletionResult,
-    StreamChunk,
-    ModelInfo,
+  Provider,
+  ChatMessage,
+  ChatCompletionOptions,
+  ChatCompletionResult,
+  StreamChunk,
+  ModelInfo,
 } from './provider.js';
 import { ProviderError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
@@ -18,187 +20,176 @@ import { createHash } from 'node:crypto';
 // ── Config ────────────────────────────────────────────────────
 
 export interface AwsBedrockAgentCoreConfig {
-    region: string;
-    agentRuntimeArn: string; // e.g. arn:aws:bedrock:us-east-1:123456789012:agent-alias/AGENT_ID/ALIAS_ID
-    accessKeyId?: string;
-    secretAccessKey?: string;
-    sessionToken?: string;
-    profile?: string;
+  region: string;
+  agentRuntimeArn: string; // e.g. arn:aws:bedrock:us-east-1:123456789012:agent-alias/AGENT_ID/ALIAS_ID
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  sessionToken?: string;
+  profile?: string;
 }
 
 // ── AWS Bedrock Agent Core Provider ──────────────────────────
 
 export class AwsBedrockAgentCoreProvider implements Provider {
-    readonly name = 'aws-bedrock-agent-core';
-    readonly supportsTools = false; // Agent handles tools
+  readonly name = 'aws-bedrock-agent-core';
+  readonly supportsTools = false; // Agent handles tools
 
-    private readonly client: BedrockAgentRuntimeClient;
-    private readonly agentId: string;
-    private readonly agentAliasId: string;
-    private readonly config: AwsBedrockAgentCoreConfig;
-    private readonly log = getLogger();
+  private readonly client: BedrockAgentRuntimeClient;
+  private readonly agentId: string;
+  private readonly agentAliasId: string;
+  private readonly config: AwsBedrockAgentCoreConfig;
+  private readonly log = getLogger();
 
-    constructor(config: AwsBedrockAgentCoreConfig) {
-        this.config = config;
-        // ARN: arn:aws:bedrock:region:account-id:agent-alias/agent-id/alias-id
-        const parts = config.agentRuntimeArn.split('/');
-        if (parts.length < 3) {
-            throw new Error(`Invalid Agent Runtime ARN: ${config.agentRuntimeArn}`);
-        }
-        this.agentId = parts[1]!;
-        this.agentAliasId = parts[2]!;
+  constructor(config: AwsBedrockAgentCoreConfig) {
+    this.config = config;
+    // ARN: arn:aws:bedrock:region:account-id:agent-alias/agent-id/alias-id
+    const parts = config.agentRuntimeArn.split('/');
+    if (parts.length < 3) {
+      throw new Error(`Invalid Agent Runtime ARN: ${config.agentRuntimeArn}`);
+    }
+    this.agentId = parts[1]!;
+    this.agentAliasId = parts[2]!;
 
-        const clientConfig: any = {
-            region: config.region,
-        };
+    const clientConfig: BedrockAgentRuntimeClientConfig = {
+      region: config.region,
+    };
 
-        if (config.accessKeyId && config.secretAccessKey) {
-            clientConfig.credentials = {
-                accessKeyId: config.accessKeyId,
-                secretAccessKey: config.secretAccessKey,
-                sessionToken: config.sessionToken,
-            };
-        } else if (config.profile) {
-            // Set AWS_PROFILE to rely on standard credential chain
-            process.env.AWS_PROFILE = config.profile;
-        }
-
-        this.client = new BedrockAgentRuntimeClient(clientConfig);
+    if (config.accessKeyId && config.secretAccessKey) {
+      clientConfig.credentials = {
+        accessKeyId: config.accessKeyId,
+        secretAccessKey: config.secretAccessKey,
+        sessionToken: config.sessionToken,
+      };
+    } else if (config.profile) {
+      // Set AWS_PROFILE to rely on standard credential chain
+      process.env.AWS_PROFILE = config.profile;
     }
 
-    // ── listModels ────────────────────────────────────────────
+    this.client = new BedrockAgentRuntimeClient(clientConfig);
+  }
 
-    async listModels(): Promise<ModelInfo[]> {
-        return [
-            {
-                id: this.config.agentRuntimeArn, // User requested full ARN
-                description: `AWS Bedrock Agent (${this.agentAliasId})`,
-            },
-        ];
+  // ── listModels ────────────────────────────────────────────
+
+  async listModels(): Promise<ModelInfo[]> {
+    return [
+      {
+        id: this.config.agentRuntimeArn, // User requested full ARN
+        description: `AWS Bedrock Agent (${this.agentAliasId})`,
+      },
+    ];
+  }
+
+  // ── Non-streaming completion ──────────────────────────────
+
+  async createChatCompletion(
+    messages: ChatMessage[],
+    _options: ChatCompletionOptions,
+  ): Promise<ChatCompletionResult> {
+    const { inputText, sessionId } = this.prepareRequest(messages);
+
+    try {
+      this.log.debug({ agentId: this.agentId, sessionId }, 'Invoking Bedrock Agent');
+
+      const command = new InvokeAgentCommand({
+        agentId: this.agentId,
+        agentAliasId: this.agentAliasId,
+        sessionId,
+        inputText,
+      });
+
+      const response = await this.client.send(command);
+      const content = await this.processResponse(response);
+
+      return {
+        message: { role: 'assistant', content },
+        finishReason: 'stop',
+      };
+    } catch (err: unknown) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      throw new ProviderError(`Bedrock Agent invocation failed: ${errorMessage}`, undefined, err instanceof Error ? err : new Error(errorMessage));
+    }
+  }
+
+  // ── Streaming completion ──────────────────────────────────
+
+  async *createStreamingChatCompletion(
+    messages: ChatMessage[],
+    _options: ChatCompletionOptions,
+  ): AsyncIterable<StreamChunk> {
+    const { inputText, sessionId } = this.prepareRequest(messages);
+
+    try {
+      this.log.debug({ agentId: this.agentId, sessionId }, 'Invoking Bedrock Agent (streaming)');
+
+      const command = new InvokeAgentCommand({
+        agentId: this.agentId,
+        agentAliasId: this.agentAliasId,
+        sessionId,
+        inputText,
+        enableTrace: false,
+      });
+
+      const response = await this.client.send(command);
+
+      if (!response.completion) {
+        throw new ProviderError('No completion stream in Bedrock Agent response');
+      }
+
+      for await (const event of response.completion) {
+        if (event.chunk && event.chunk.bytes) {
+          const chunkText = new TextDecoder().decode(event.chunk.bytes);
+          yield {
+            delta: { content: chunkText },
+            finishReason: null,
+          };
+        }
+      }
+
+      yield { delta: {}, finishReason: 'stop' };
+    } catch (err: unknown) {
+      if (err instanceof ProviderError) throw err;
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      throw new ProviderError(`Bedrock Agent streaming failed: ${errorMessage}`, undefined, err instanceof Error ? err : new Error(errorMessage));
+    }
+  }
+
+  // ── Internal helpers ──────────────────────────────────────
+
+  private prepareRequest(messages: ChatMessage[]): {
+    inputText: string;
+    sessionId: string;
+  } {
+    // Send the last user message as input (Agent manages its own memory)
+    const lastMsg = messages[messages.length - 1];
+    if (lastMsg?.role !== 'user' || !lastMsg.content) {
+      throw new ProviderError('History must end with a user message for Agents.');
     }
 
-    // ── Non-streaming completion ──────────────────────────────
+    // Generate a session ID: hash(ARN + timestamp) to fit AWS requirements
+    // AWS Bedrock Agent SessionID must be alphanumeric, 2-100 chars
+    const rawId = `${this.config.agentRuntimeArn}-${Date.now()}`;
+    const sessionId = createHash('sha256').update(rawId).digest('hex').substring(0, 32);
 
-    async createChatCompletion(
-        messages: ChatMessage[],
-        _options: ChatCompletionOptions,
-    ): Promise<ChatCompletionResult> {
-        const { inputText, sessionId } = this.prepareRequest(messages);
+    return {
+      inputText: lastMsg.content,
+      sessionId,
+    };
+  }
 
-        try {
-            this.log.debug({ agentId: this.agentId, sessionId }, 'Invoking Bedrock Agent');
+  private async processResponse(response: InvokeAgentCommandOutput): Promise<string> {
+    const chunks: string[] = [];
 
-            const command = new InvokeAgentCommand({
-                agentId: this.agentId,
-                agentAliasId: this.agentAliasId,
-                sessionId,
-                inputText,
-            });
-
-            const response = await this.client.send(command);
-            const content = await this.processResponse(response);
-
-            return {
-                message: { role: 'assistant', content },
-                finishReason: 'stop',
-            };
-        } catch (err: any) {
-            throw new ProviderError(
-                `Bedrock Agent invocation failed: ${err.message}`,
-                undefined,
-                err,
-            );
-        }
+    if (!response.completion) {
+      return '';
     }
 
-    // ── Streaming completion ──────────────────────────────────
-
-    async *createStreamingChatCompletion(
-        messages: ChatMessage[],
-        _options: ChatCompletionOptions,
-    ): AsyncIterable<StreamChunk> {
-        const { inputText, sessionId } = this.prepareRequest(messages);
-
-        try {
-            this.log.debug(
-                { agentId: this.agentId, sessionId },
-                'Invoking Bedrock Agent (streaming)',
-            );
-
-            const command = new InvokeAgentCommand({
-                agentId: this.agentId,
-                agentAliasId: this.agentAliasId,
-                sessionId,
-                inputText,
-                enableTrace: false,
-            });
-
-            const response = await this.client.send(command);
-
-            if (!response.completion) {
-                throw new ProviderError('No completion stream in Bedrock Agent response');
-            }
-
-            for await (const event of response.completion) {
-                if (event.chunk && event.chunk.bytes) {
-                    const chunkText = new TextDecoder().decode(event.chunk.bytes);
-                    yield {
-                        delta: { content: chunkText },
-                        finishReason: null,
-                    };
-                }
-            }
-
-            yield { delta: {}, finishReason: 'stop' };
-        } catch (err: any) {
-            if (err instanceof ProviderError) throw err;
-            throw new ProviderError(
-                `Bedrock Agent streaming failed: ${err.message}`,
-                undefined,
-                err
-            );
-        }
+    for await (const event of response.completion) {
+      if (event.chunk && event.chunk.bytes) {
+        const text = new TextDecoder().decode(event.chunk.bytes);
+        chunks.push(text);
+      }
     }
 
-    // ── Internal helpers ──────────────────────────────────────
-
-    private prepareRequest(messages: ChatMessage[]): {
-        inputText: string;
-        sessionId: string;
-    } {
-        // Send the last user message as input (Agent manages its own memory)
-        const lastMsg = messages[messages.length - 1];
-        if (lastMsg?.role !== 'user' || !lastMsg.content) {
-            throw new ProviderError('History must end with a user message for Agents.');
-        }
-
-        // Generate a session ID: hash(ARN + timestamp) to fit AWS requirements
-        // AWS Bedrock Agent SessionID must be alphanumeric, 2-100 chars
-        const rawId = `${this.config.agentRuntimeArn}-${Date.now()}`;
-        const sessionId = createHash('sha256').update(rawId).digest('hex').substring(0, 32);
-
-        return {
-            inputText: lastMsg.content,
-            sessionId,
-        };
-    }
-
-    private async processResponse(
-        response: InvokeAgentCommandOutput,
-    ): Promise<string> {
-        const chunks: string[] = [];
-
-        if (!response.completion) {
-            return '';
-        }
-
-        for await (const event of response.completion) {
-            if (event.chunk && event.chunk.bytes) {
-                const text = new TextDecoder().decode(event.chunk.bytes);
-                chunks.push(text);
-            }
-        }
-
-        return chunks.join('');
-    }
+    return chunks.join('');
+  }
 }

--- a/src/providers/awsBedrockAgentCore.ts
+++ b/src/providers/awsBedrockAgentCore.ts
@@ -1,0 +1,199 @@
+import {
+    BedrockAgentRuntimeClient,
+    InvokeAgentCommand,
+    InvokeAgentCommandOutput,
+} from '@aws-sdk/client-bedrock-agent-runtime';
+import type {
+    Provider,
+    ChatMessage,
+    ChatCompletionOptions,
+    ChatCompletionResult,
+    StreamChunk,
+    ModelInfo,
+} from './provider.js';
+import { ProviderError } from '../util/errors.js';
+import { getLogger } from '../util/logger.js';
+
+// ── Config ────────────────────────────────────────────────────
+
+export interface AwsBedrockAgentCoreConfig {
+    region: string;
+    agentRuntimeArn: string; // e.g. arn:aws:bedrock:us-east-1:123456789012:agent-alias/AGENT_ID/ALIAS_ID
+    accessKeyId?: string;
+    secretAccessKey?: string;
+    sessionToken?: string;
+    profile?: string;
+}
+
+// ── AWS Bedrock Agent Core Provider ──────────────────────────
+
+export class AwsBedrockAgentCoreProvider implements Provider {
+    readonly name = 'aws-bedrock-agent-core';
+    readonly supportsTools = false; // Agent handles tools
+
+    private readonly client: BedrockAgentRuntimeClient;
+    private readonly agentId: string;
+    private readonly agentAliasId: string;
+    private readonly log = getLogger();
+
+    constructor(config: AwsBedrockAgentCoreConfig) {
+        // ARN: arn:aws:bedrock:region:account-id:agent-alias/agent-id/alias-id
+        const parts = config.agentRuntimeArn.split('/');
+        if (parts.length < 3) {
+            throw new Error(`Invalid Agent Runtime ARN: ${config.agentRuntimeArn}`);
+        }
+        this.agentId = parts[1]!;
+        this.agentAliasId = parts[2]!;
+
+        const clientConfig: any = {
+            region: config.region,
+        };
+
+        if (config.accessKeyId && config.secretAccessKey) {
+            clientConfig.credentials = {
+                accessKeyId: config.accessKeyId,
+                secretAccessKey: config.secretAccessKey,
+                sessionToken: config.sessionToken,
+            };
+        } else if (config.profile) {
+            // Set AWS_PROFILE to rely on standard credential chain
+            process.env.AWS_PROFILE = config.profile;
+        }
+
+        this.client = new BedrockAgentRuntimeClient(clientConfig);
+    }
+
+    // ── listModels ────────────────────────────────────────────
+
+    async listModels(): Promise<ModelInfo[]> {
+        return [
+            {
+                id: this.agentId,
+                description: `AWS Bedrock Agent (${this.agentAliasId})`,
+            },
+        ];
+    }
+
+    // ── Non-streaming completion ──────────────────────────────
+
+    async createChatCompletion(
+        messages: ChatMessage[],
+        _options: ChatCompletionOptions,
+    ): Promise<ChatCompletionResult> {
+        const { inputText, sessionId } = this.prepareRequest(messages);
+
+        try {
+            this.log.debug({ agentId: this.agentId, sessionId }, 'Invoking Bedrock Agent');
+
+            const command = new InvokeAgentCommand({
+                agentId: this.agentId,
+                agentAliasId: this.agentAliasId,
+                sessionId,
+                inputText,
+            });
+
+            const response = await this.client.send(command);
+            const content = await this.processResponse(response);
+
+            return {
+                message: { role: 'assistant', content },
+                finishReason: 'stop',
+            };
+        } catch (err: any) {
+            throw new ProviderError(
+                `Bedrock Agent invocation failed: ${err.message}`,
+                undefined,
+                err,
+            );
+        }
+    }
+
+    // ── Streaming completion ──────────────────────────────────
+
+    async *createStreamingChatCompletion(
+        messages: ChatMessage[],
+        _options: ChatCompletionOptions,
+    ): AsyncIterable<StreamChunk> {
+        const { inputText, sessionId } = this.prepareRequest(messages);
+
+        try {
+            this.log.debug(
+                { agentId: this.agentId, sessionId },
+                'Invoking Bedrock Agent (streaming)',
+            );
+
+            const command = new InvokeAgentCommand({
+                agentId: this.agentId,
+                agentAliasId: this.agentAliasId,
+                sessionId,
+                inputText,
+                enableTrace: false,
+            });
+
+            const response = await this.client.send(command);
+
+            if (!response.completion) {
+                throw new ProviderError('No completion stream in Bedrock Agent response');
+            }
+
+            for await (const event of response.completion) {
+                if (event.chunk && event.chunk.bytes) {
+                    const chunkText = new TextDecoder().decode(event.chunk.bytes);
+                    yield {
+                        delta: { content: chunkText },
+                        finishReason: null,
+                    };
+                }
+            }
+
+            yield { delta: {}, finishReason: 'stop' };
+        } catch (err: any) {
+            if (err instanceof ProviderError) throw err;
+            throw new ProviderError(
+                `Bedrock Agent streaming failed: ${err.message}`,
+                undefined,
+                err
+            );
+        }
+    }
+
+    // ── Internal helpers ──────────────────────────────────────
+
+    private prepareRequest(messages: ChatMessage[]): {
+        inputText: string;
+        sessionId: string;
+    } {
+        // Send the last user message as input (Agent manages its own memory)
+        const lastMsg = messages[messages.length - 1];
+        if (lastMsg?.role !== 'user' || !lastMsg.content) {
+            throw new ProviderError('History must end with a user message for Agents.');
+        }
+
+        // Generate a new session ID for each request
+        const sessionId = `session-${Date.now()}`;
+
+        return {
+            inputText: lastMsg.content,
+            sessionId,
+        };
+    }
+
+    private async processResponse(
+        response: InvokeAgentCommandOutput,
+    ): Promise<string> {
+        const chunks: string[] = [];
+
+        if (!response.completion) {
+            return '';
+        }
+
+        for await (const event of response.completion) {
+            if (event.chunk && event.chunk.bytes) {
+                const text = new TextDecoder().decode(event.chunk.bytes);
+                chunks.push(text);
+            }
+        }
+
+        return chunks.join('');
+    }
+}

--- a/test/awsBedrockAgentCore.test.ts
+++ b/test/awsBedrockAgentCore.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+    AwsBedrockAgentCoreProvider,
+    AwsBedrockAgentCoreConfig,
+} from '../src/providers/awsBedrockAgentCore.js';
+import { BedrockAgentRuntimeClient, InvokeAgentCommand } from '@aws-sdk/client-bedrock-agent-runtime';
+
+// ── Mocks ─────────────────────────────────────────────────────
+vi.mock('@aws-sdk/client-bedrock-agent-runtime', () => {
+    const BedrockAgentRuntimeClient = vi.fn();
+    BedrockAgentRuntimeClient.prototype.send = vi.fn();
+    return {
+        BedrockAgentRuntimeClient,
+        InvokeAgentCommand: vi.fn(),
+    };
+});
+
+// ── Config ────────────────────────────────────────────────────
+
+const mockConfig: AwsBedrockAgentCoreConfig = {
+    region: 'us-east-1',
+    agentRuntimeArn: 'arn:aws:bedrock:us-east-1:123456789012:agent-alias/AGENT_ID/ALIAS_ID',
+    accessKeyId: 'test-key',
+    secretAccessKey: 'test-secret',
+};
+
+// ── AWS Bedrock Agent Core Provider ──────────────────────────
+
+describe('AwsBedrockAgentCoreProvider', () => {
+    let provider: AwsBedrockAgentCoreProvider;
+    let mockClient: any;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        provider = new AwsBedrockAgentCoreProvider(mockConfig);
+        mockClient = (BedrockAgentRuntimeClient as any).mock.instances[0];
+    });
+    it('has the correct provider name', () => {
+        expect(provider.name).toBe('aws-bedrock-agent-core');
+    });
+    it('initializes the client with correct config', () => {
+        expect(BedrockAgentRuntimeClient).toHaveBeenCalledWith(
+            expect.objectContaining({
+                region: 'us-east-1',
+                credentials: {
+                    accessKeyId: 'test-key',
+                    secretAccessKey: 'test-secret',
+                    sessionToken: undefined,
+                },
+            }),
+        );
+    });
+
+    it('calls invokeAgent for non-streaming completion', async () => {
+        const mockResponse = {
+            completion: (async function* () {
+                yield { chunk: { bytes: new TextEncoder().encode('Hello from Agent') } };
+            })(),
+        };
+        mockClient.send.mockResolvedValue(mockResponse);
+
+        const result = await provider.createChatCompletion(
+            [{ role: 'user', content: 'Hello' }],
+            { model: 'agent' },
+        );
+
+        expect(mockClient.send).toHaveBeenCalled();
+        const commandCall = (InvokeAgentCommand as any).mock.calls[0][0];
+        expect(commandCall).toEqual({
+            agentId: 'AGENT_ID',
+            agentAliasId: 'ALIAS_ID',
+            sessionId: expect.stringMatching(/^session-\d+$/),
+            inputText: 'Hello',
+        });
+
+        expect(result.message.content).toBe('Hello from Agent');
+        expect(result.finishReason).toBe('stop');
+    });
+
+    it('calls invokeAgent for streaming completion', async () => {
+        const mockResponse = {
+            completion: (async function* () {
+                yield { chunk: { bytes: new TextEncoder().encode('Hello ') } };
+                yield { chunk: { bytes: new TextEncoder().encode('World') } };
+            })(),
+        };
+        mockClient.send.mockResolvedValue(mockResponse);
+
+        const stream = provider.createStreamingChatCompletion(
+            [{ role: 'user', content: 'Stream me' }],
+            { model: 'agent' },
+        );
+
+        const chunks = [];
+        for await (const chunk of stream) {
+            if (chunk.delta.content) {
+                chunks.push(chunk.delta.content);
+            }
+        }
+
+        expect(chunks).toEqual(['Hello ', 'World']);
+        expect(mockClient.send).toHaveBeenCalled();
+    });
+
+    it('throws error if history does not end with user message', async () => {
+        await expect(
+            provider.createChatCompletion([{ role: 'assistant', content: 'Hi' }], { model: 'agent' }),
+        ).rejects.toThrow('History must end with a user message');
+    });
+});

--- a/test/awsBedrockAgentCore.test.ts
+++ b/test/awsBedrockAgentCore.test.ts
@@ -1,117 +1,121 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
-    AwsBedrockAgentCoreProvider,
-    AwsBedrockAgentCoreConfig,
+  AwsBedrockAgentCoreProvider,
+  AwsBedrockAgentCoreConfig,
 } from '../src/providers/awsBedrockAgentCore.js';
-import { BedrockAgentRuntimeClient, InvokeAgentCommand } from '@aws-sdk/client-bedrock-agent-runtime';
-import { createHash } from 'node:crypto';
+import {
+  BedrockAgentRuntimeClient,
+  InvokeAgentCommand,
+} from '@aws-sdk/client-bedrock-agent-runtime';
+
 
 // ── Mocks ─────────────────────────────────────────────────────
 vi.mock('@aws-sdk/client-bedrock-agent-runtime', () => {
-    const BedrockAgentRuntimeClient = vi.fn();
-    BedrockAgentRuntimeClient.prototype.send = vi.fn();
-    return {
-        BedrockAgentRuntimeClient,
-        InvokeAgentCommand: vi.fn(),
-    };
+  const BedrockAgentRuntimeClient = vi.fn();
+  BedrockAgentRuntimeClient.prototype.send = vi.fn();
+  return {
+    BedrockAgentRuntimeClient,
+    InvokeAgentCommand: vi.fn(),
+  };
 });
 
 // ── Config ────────────────────────────────────────────────────
 
 const mockConfig: AwsBedrockAgentCoreConfig = {
-    region: 'us-east-1',
-    agentRuntimeArn: 'arn:aws:bedrock:us-east-1:123456789012:agent-alias/AGENT_ID/ALIAS_ID',
-    accessKeyId: 'test-key',
-    secretAccessKey: 'test-secret',
+  region: 'us-east-1',
+  agentRuntimeArn: 'arn:aws:bedrock:us-east-1:123456789012:agent-alias/AGENT_ID/ALIAS_ID',
+  accessKeyId: 'test-key',
+  secretAccessKey: 'test-secret',
 };
 
 // ── AWS Bedrock Agent Core Provider ──────────────────────────
 
 describe('AwsBedrockAgentCoreProvider', () => {
-    let provider: AwsBedrockAgentCoreProvider;
-    let mockClient: any;
+  let provider: AwsBedrockAgentCoreProvider;
+  let mockClient: any;
 
-    beforeEach(() => {
-        vi.clearAllMocks();
-        provider = new AwsBedrockAgentCoreProvider(mockConfig);
-        mockClient = (BedrockAgentRuntimeClient as any).mock.instances[0];
-    });
-    it('listModels returns the full Agent Runtime ARN', async () => {
-        const models = await provider.listModels();
-        expect(models).toHaveLength(1);
-        expect(models[0].id).toBe(mockConfig.agentRuntimeArn);
-        expect(models[0].description).toBe('AWS Bedrock Agent (ALIAS_ID)');
-    });
-    it('initializes the client with correct config', () => {
-        expect(BedrockAgentRuntimeClient).toHaveBeenCalledWith(
-            expect.objectContaining({
-                region: 'us-east-1',
-                credentials: {
-                    accessKeyId: 'test-key',
-                    secretAccessKey: 'test-secret',
-                    sessionToken: undefined,
-                },
-            }),
-        );
-    });
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new AwsBedrockAgentCoreProvider(mockConfig);
+    mockClient = (BedrockAgentRuntimeClient as any).mock.instances[0];
+  });
+  it('listModels returns the full Agent Runtime ARN', async () => {
+    const models = await provider.listModels();
+    expect(models).toHaveLength(1);
+    expect(models[0].id).toBe(mockConfig.agentRuntimeArn);
+    expect(models[0].description).toBe('AWS Bedrock Agent (ALIAS_ID)');
+  });
+  it('initializes the client with correct config', () => {
+    expect(BedrockAgentRuntimeClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        region: 'us-east-1',
+        credentials: {
+          accessKeyId: 'test-key',
+          secretAccessKey: 'test-secret',
+          sessionToken: undefined,
+        },
+      }),
+    );
+  });
 
-    it('calls invokeAgent for non-streaming completion', async () => {
-        const mockResponse = {
-            completion: (async function* () {
-                yield { chunk: { bytes: new TextEncoder().encode('Hello from Agent') } };
-            })(),
-        };
-        mockClient.send.mockResolvedValue(mockResponse);
+  it('calls invokeAgent for non-streaming completion', async () => {
+    const mockResponse = {
+      completion: (async function* () {
+        yield { chunk: { bytes: new TextEncoder().encode('Hello from Agent') } };
+      })(),
+    };
+    mockClient.send.mockResolvedValue(mockResponse);
 
-        const result = await provider.createChatCompletion(
-            [{ role: 'user', content: 'Hello' }],
-            { model: 'agent' },
-        );
-
-        expect(mockClient.send).toHaveBeenCalled();
-        const commandCall = (InvokeAgentCommand as any).mock.calls[0][0];
-
-        // Verify sessionId is a 32-char hex string (SHA-256 substring)
-        expect(commandCall.sessionId).toMatch(/^[a-f0-9]{32}$/);
-
-        expect(commandCall).toEqual(expect.objectContaining({
-            agentId: 'AGENT_ID',
-            agentAliasId: 'ALIAS_ID',
-            inputText: 'Hello',
-        }));
-
-        expect(result.message.content).toBe('Hello from Agent');
-        expect(result.finishReason).toBe('stop');
+    const result = await provider.createChatCompletion([{ role: 'user', content: 'Hello' }], {
+      model: 'agent',
     });
 
-    it('calls invokeAgent for streaming completion', async () => {
-        const mockResponse = {
-            completion: (async function* () {
-                yield { chunk: { bytes: new TextEncoder().encode('Hello ') } };
-                yield { chunk: { bytes: new TextEncoder().encode('World') } };
-            })(),
-        };
-        mockClient.send.mockResolvedValue(mockResponse);
+    expect(mockClient.send).toHaveBeenCalled();
+    const commandCall = (InvokeAgentCommand as any).mock.calls[0][0];
 
-        const stream = provider.createStreamingChatCompletion(
-            [{ role: 'user', content: 'Stream me' }],
-            { model: 'agent' },
-        );
+    // Verify sessionId is a 32-char hex string (SHA-256 substring)
+    expect(commandCall.sessionId).toMatch(/^[a-f0-9]{32}$/);
 
-        const chunks = [];
-        for await (const chunk of stream) {
-            if (chunk.delta.content) {
-                chunks.push(chunk.delta.content);
-            }
-        }
+    expect(commandCall).toEqual(
+      expect.objectContaining({
+        agentId: 'AGENT_ID',
+        agentAliasId: 'ALIAS_ID',
+        inputText: 'Hello',
+      }),
+    );
 
-        expect(chunks).toEqual(['Hello ', 'World']);
-        expect(mockClient.send).toHaveBeenCalled();
-    });
+    expect(result.message.content).toBe('Hello from Agent');
+    expect(result.finishReason).toBe('stop');
+  });
 
-    it('throws error if history does not end with user message', async () => {
-        await expect(
-            provider.createChatCompletion([{ role: 'assistant', content: 'Hi' }], { model: 'agent' }),
-        ).rejects.toThrow('History must end with a user message');
-    });
+  it('calls invokeAgent for streaming completion', async () => {
+    const mockResponse = {
+      completion: (async function* () {
+        yield { chunk: { bytes: new TextEncoder().encode('Hello ') } };
+        yield { chunk: { bytes: new TextEncoder().encode('World') } };
+      })(),
+    };
+    mockClient.send.mockResolvedValue(mockResponse);
+
+    const stream = provider.createStreamingChatCompletion(
+      [{ role: 'user', content: 'Stream me' }],
+      { model: 'agent' },
+    );
+
+    const chunks = [];
+    for await (const chunk of stream) {
+      if (chunk.delta.content) {
+        chunks.push(chunk.delta.content);
+      }
+    }
+
+    expect(chunks).toEqual(['Hello ', 'World']);
+    expect(mockClient.send).toHaveBeenCalled();
+  });
+
+  it('throws error if history does not end with user message', async () => {
+    await expect(
+      provider.createChatCompletion([{ role: 'assistant', content: 'Hi' }], { model: 'agent' }),
+    ).rejects.toThrow('History must end with a user message');
+  });
 });


### PR DESCRIPTION
Closes #5 

## Amazon Bedrock AgentCore Provider

### Description
This PR introduces a new provider for **Amazon Bedrock Agents**, allowing CaretForge to invoke agents directly via the AWS SDK. This enables users to utilize custom Bedrock Agents (orchestrated with Lambda, Knowledge Bases, etc.) as backend coding assistants.

### Key Changes
*   **New Provider:** Implemented [AwsBedrockAgentCoreProvider (cci:2://file:///Users/nabil/Downloads/caretforge/src/providers/awsBedrockAgentCore.ts:32:0-194:1) in [src/providers/awsBedrockAgentCore.ts](cci:7://file:///Users/nabil/Downloads/caretforge/src/providers/awsBedrockAgentCore.ts:0:0-0:0) using the `@aws-sdk/client-bedrock-agent-runtime`.
*   **Configuration:** Added `awsBedrockAgentCore` schema to [src/config/schema.ts](cci:7://file:///Users/nabil/Downloads/caretforge/src/config/schema.ts:0:0-0:0), supporting standard AWS authentication methods (Profile, Access Keys, Environment Variables).
*   **CLI Integration:** Registered the new provider in [src/cli/shared.ts](cci:7://file:///Users/nabil/Downloads/caretforge/src/cli/shared.ts:0:0-0:0) for both interactive chat and one-shot tasks.
*   **Documentation:** Updated [README.md](cci:7://file:///Users/nabil/Downloads/caretforge/README.md:0:0-0:0) and [docs/reference/configuration.md](cci:7://file:///Users/nabil/Downloads/caretforge/docs/reference/configuration.md:0:0-0:0) with setup instructions and credential resolution details.
*   **Testing:** Added comprehensive unit tests in [test/awsBedrockAgentCore.test.ts](cci:7://file:///Users/nabil/Downloads/caretforge/test/awsBedrockAgentCore.test.ts:0:0-0:0) covering both streaming and non-streaming responses.

### Testing
Ran the full test suite (`npm test`), confirming all tests pass:
*   [AwsBedrockAgentCoreProvider](cci:2://file:///Users/nabil/Downloads/caretforge/src/providers/awsBedrockAgentCore.ts:32:0-194:1) tests passed (5/5).
*   Verified integration with existing providers (resolved merge conflicts with `azure-responses`).

### Configuration Example
Users can now configure an AWS Bedrock Agent in `~/.config/caretforge/config.json`:

```json
{
  "defaultProvider": "aws-bedrock-agent-core",
  "providers": {
    "awsBedrockAgentCore": {
      "region": "us-east-1",
      "agentRuntimeArn": "arn:aws:bedrock:us-east-1:123456789012:agent-alias/AGENT_ID/ALIAS_ID",
      "profile": "default"
    }
  }
}